### PR TITLE
feat: npm audit fix - override path-to-regexp to 0.1.13 for ReDoS vul…

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
       "http-proxy-middleware": "2.0.9",
       "cookie": "0.7.0",
       "cross-spawn": "7.0.5",
-      "path-to-regexp@<0.1.12": "0.1.12",
+      "path-to-regexp@<0.1.13": "0.1.13",
       "@babel/runtime-corejs3": "7.26.10",
       "@babel/runtime": "7.26.10",
       "@babel/helpers": "7.26.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ overrides:
   http-proxy-middleware: 2.0.9
   cookie: 0.7.0
   cross-spawn: 7.0.5
-  path-to-regexp@<0.1.12: 0.1.12
+  path-to-regexp@<0.1.13: 0.1.13
   '@babel/runtime-corejs3': 7.26.10
   '@babel/runtime': 7.26.10
   '@babel/helpers': 7.26.10
@@ -4321,7 +4321,7 @@ packages:
       methods: 1.1.2
       on-finished: 2.4.1
       parseurl: 1.3.3
-      path-to-regexp: 0.1.12
+      path-to-regexp: 0.1.13
       proxy-addr: 2.0.7
       qs: 6.14.1
       range-parser: 1.2.1
@@ -5987,8 +5987,8 @@ packages:
       minipass: 7.1.2
     dev: true
 
-  /path-to-regexp/0.1.12:
-    resolution: {integrity: sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==}
+  /path-to-regexp/0.1.13:
+    resolution: {integrity: sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==}
     dev: true
 
   /path-type/4.0.0:


### PR DESCRIPTION
1. fix npm security issues