### PR TITLE
ci: ensure Node 20.19.2 is installed before use in build workflow

### DIFF
--- a/.github/workflows/build-and-upload.yml
+++ b/.github/workflows/build-and-upload.yml
@@ -23,10 +23,10 @@ jobs:
         run: |
           export NVM_DIR="$HOME/.nvm"
           [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+          nvm install 20.19.2
           nvm use 20.19.2
           npm install -g pnpm@10.12.4
           pnpm --version
-
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
1. installed Node 20.19.2  in build workflow