### PR TITLE
fix: align personal_sign with EIP-191 and bump to 1.0.19

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tronlink/core",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "description": "The library serves as a core module within TronLink Extension, which provides low-level wallet functionality for both Tron and Ethereum networks, primary features includes account generation and transaction signing",
   "repository": {
     "type": "git",

--- a/src/evm_wallet/EvmWallet.ts
+++ b/src/evm_wallet/EvmWallet.ts
@@ -27,7 +27,7 @@ import type {
 } from '../base_wallet/types';
 import { BaseWallet } from '../base_wallet';
 import { CoinType } from '../base_wallet/constants';
-import { msgHexToText } from './util';
+import { messageToBuffer } from './util';
 import { checkSignParams } from '../utils';
 import { InvalidParameterError, SignError } from '../base_wallet/error';
 
@@ -90,9 +90,8 @@ export class EvmWallet extends BaseWallet {
         'The "data" parameter of the function "signMessage" must be passed in string type',
       );
     }
-    const textMessage = msgHexToText(param.data);
     const signature = ecsign(
-      hashPersonalMessage(Buffer.from(textMessage)),
+      hashPersonalMessage(messageToBuffer(param.data)),
       Buffer.from(param.privateKey, 'hex'),
     );
     const rawMsgSign = this.signedConvertRSVtoHex({
@@ -121,7 +120,7 @@ export class EvmWallet extends BaseWallet {
 
   public verifyEthMessageSign(signature: string, message: string, expectAddress: string) {
     const { r, s, v } = fromRpcSig(signature);
-    const publicKey = ecrecover(hashPersonalMessage(Buffer.from(msgHexToText(message))), v, r, s);
+    const publicKey = ecrecover(hashPersonalMessage(messageToBuffer(message)), v, r, s);
     const address = publicToAddress(publicKey, true);
     return `${address.toString('hex').toLowerCase()}` === stripHexPrefix(expectAddress).toLowerCase();
   }

--- a/src/evm_wallet/ledger/LedgerEvmSigner.ts
+++ b/src/evm_wallet/ledger/LedgerEvmSigner.ts
@@ -3,7 +3,7 @@ import { ethers } from 'ethers';
 import { SignError } from '../../base_wallet/error';
 import { LedgerSigner } from '../../base_wallet/ledger/LedgerSigner';
 import { LedgerSignParams } from '../../base_wallet/types';
-import { isHex, msgHexToText } from '../util';
+import { messageToBuffer } from '../util';
 import { LedgerEthWebHid } from './LedgerEthWebHid';
 
 const regStartWithZeroX = new RegExp(/^0x/i);
@@ -16,9 +16,7 @@ export class LedgerEvmSigner extends LedgerSigner {
       let signedResponse;
       if (typeof transaction === 'string') {
         signedResponse = await ledgerWebHid.signPersonalMessage(
-          isHex(transaction.replace(regStartWithZeroX, ''))
-            ? msgHexToText(Buffer.from(transaction.replace(regStartWithZeroX, ''), 'utf8').toString('hex'))
-            : Buffer.from(transaction, 'utf8').toString('hex'),
+          messageToBuffer(transaction).toString('hex'),
           path,
         );
       } else {

--- a/src/evm_wallet/util.ts
+++ b/src/evm_wallet/util.ts
@@ -1,39 +1,14 @@
-import { stripHexPrefix } from '@ethereumjs/util';
+const HEX_MESSAGE_REGEX = /^0x[0-9a-fA-F]+$/;
 
-export function isHex(hex: string) {
-  return /^[A-Fa-f0-9]+$/.test(hex);
+export function isHexMessage(value: string): boolean {
+  return HEX_MESSAGE_REGEX.test(value);
 }
 
-export const splitStringByLength = ({ str, length }: { str: string; length: number }) => {
-  const arr = [];
-  let index = 0;
-  if (length < 1) {
-    length = 1;
+export function messageToBuffer(message: string): Buffer {
+  if (isHexMessage(message)) {
+    const stripped = message.slice(2);
+    const padded = stripped.length % 2 === 0 ? stripped : `0${stripped}`;
+    return Buffer.from(padded, 'hex');
   }
-  while (index < str.length) {
-    arr.push(str.slice(index, (index += length)));
-  }
-  return arr;
-};
-
-export function strInsert(str: string) {
-  const arr = splitStringByLength({ str, length: 2 }).map((item) => {
-    return String.fromCharCode(parseInt(`0x${item}`));
-  });
-  return arr.join('');
-}
-
-export function msgHexToText(hex: string) {
-  try {
-    const stripped = stripHexPrefix(hex);
-    const buff = Buffer.from(stripped, 'hex');
-    if (hex.indexOf('0x') === 0) {
-      return buff.toString('utf8');
-    } else if (isHex(hex)) {
-      return strInsert(hex);
-    }
-    return hex;
-  } catch (e) {
-    return hex;
-  }
+  return Buffer.from(message, 'utf8');
 }

--- a/src/tests/evm_wallet/util.test.ts
+++ b/src/tests/evm_wallet/util.test.ts
@@ -1,116 +1,66 @@
-import * as util from '../../evm_wallet/util';
-import * as ethUtil from '@ethereumjs/util';
+import { isHexMessage, messageToBuffer } from '../../evm_wallet/util';
 
-const { msgHexToText, isHex, splitStringByLength, strInsert } = util;
-
-describe('msgHexToText', () => {
-  test('converts hexadecimal string with 0x prefix to text', () => {
-    const hex = '0x68656c6c6f';
-    expect(msgHexToText(hex)).toBe('hello');
+describe('isHexMessage', () => {
+  test('returns true for 0x-prefixed even-length hex', () => {
+    expect(isHexMessage('0xae16f78a')).toBe(true);
   });
 
-  test('returns the same string for non-hexadecimal input', () => {
-    const nonHex = 'not a hex string';
-    expect(msgHexToText(nonHex)).toBe('not a hex string');
+  test('returns true for 0x-prefixed odd-length hex', () => {
+    expect(isHexMessage('0xabc')).toBe(true);
   });
 
-  test('returns the input string when hex does not start with 0x', () => {
-    const hex = '68656c6c6f';
-    expect(msgHexToText(hex)).toBe('hello');
+  test('returns true for uppercase hex', () => {
+    expect(isHexMessage('0xAE16F78A')).toBe(true);
   });
 
-  test('handles empty string input', () => {
-    expect(msgHexToText('')).toBe('');
+  test('returns false for bare hex without 0x prefix', () => {
+    expect(isHexMessage('ae16f78a')).toBe(false);
   });
 
-  test('catches and returns input on invalid hex string', () => {
-    const invalidHex = '0xZZZ';
-    expect(msgHexToText(invalidHex)).toBe('');
-  });
-
-  test('throw error', () => {
-    const invalidHex = 1234;
-    jest.mock('@ethereumjs/util', () => {
-      return {
-        stripHexPrefix: jest.fn().mockReturnValue(invalidHex),
-      };
-    });
-    // @ts-ignore
-    expect(msgHexToText(invalidHex)).toBe(invalidHex);
-  });
-});
-
-describe('isHex', () => {
-  test('returns true for valid hexadecimal string', () => {
-    const validHex = 'a1b2c3';
-    expect(isHex(validHex)).toBe(true);
-  });
-
-  test('returns false for string with non-hex characters', () => {
-    const invalidHex = 'a1b2g3';
-    expect(isHex(invalidHex)).toBe(false);
-  });
-
-  test('returns true for uppercase hexadecimal string', () => {
-    const uppercaseHex = 'A1B2C3';
-    expect(isHex(uppercaseHex)).toBe(true);
+  test('returns false for plain text', () => {
+    expect(isHexMessage('hello')).toBe(false);
   });
 
   test('returns false for empty string', () => {
-    expect(isHex('')).toBe(false);
+    expect(isHexMessage('')).toBe(false);
   });
 
-  test('returns false for string with special characters', () => {
-    const specialCharHex = 'a1b2c3#';
-    expect(isHex(specialCharHex)).toBe(false);
-  });
-});
-
-describe('splitStringByLength', () => {
-  test('correctly splits a string into specified length', () => {
-    const result = splitStringByLength({ str: 'hello world', length: 5 });
-    expect(result).toEqual(['hello', ' worl', 'd']);
+  test('returns false for "0x" alone (no hex digits)', () => {
+    expect(isHexMessage('0x')).toBe(false);
   });
 
-  test('returns entire string in a single array element when length is greater than string length', () => {
-    const result = splitStringByLength({ str: 'hello', length: 10 });
-    expect(result).toEqual(['hello']);
-  });
-
-  test('handles empty string input', () => {
-    const result = splitStringByLength({ str: '', length: 5 });
-    expect(result).toEqual([]);
-  });
-
-  test('handles zero length', () => {
-    const result = splitStringByLength({ str: 'hello', length: 0 });
-    expect(result).toEqual(['h', 'e', 'l', 'l', 'o']);
-  });
-
-  test('handles string with length exactly divisible by the specified length', () => {
-    const result = splitStringByLength({ str: 'abcdef', length: 2 });
-    expect(result).toEqual(['ab', 'cd', 'ef']);
+  test('returns false for 0x-prefixed string with non-hex chars', () => {
+    expect(isHexMessage('0xZZZ')).toBe(false);
   });
 });
 
-describe('strInsert', () => {
-  test('correctly converts hexadecimal string to text', () => {
-    expect(strInsert('68656c6c6f')).toBe('hello');
+describe('messageToBuffer', () => {
+  test('hex-decodes 0x-prefixed even-length hex into raw bytes', () => {
+    const buf = messageToBuffer('0xae16f78a');
+    expect(Array.from(buf)).toEqual([0xae, 0x16, 0xf7, 0x8a]);
   });
 
-  test('returns empty string for empty input', () => {
-    expect(strInsert('')).toBe('');
+  test('left-pads 0x-prefixed odd-length hex with a leading zero', () => {
+    const buf = messageToBuffer('0xabc');
+    expect(Array.from(buf)).toEqual([0x0a, 0xbc]);
   });
 
-  test('handles single character hex string', () => {
-    expect(strInsert('68')).toBe('h');
+  test('utf8-encodes plain text', () => {
+    const buf = messageToBuffer('hello');
+    expect(Array.from(buf)).toEqual([0x68, 0x65, 0x6c, 0x6c, 0x6f]);
   });
 
-  test('returns correct string for mixed-case hex input', () => {
-    expect(strInsert('48656C6C6F')).toBe('Hello');
+  test('utf8-encodes bare hex (no 0x) as a string of ASCII characters', () => {
+    const buf = messageToBuffer('ae16f78a');
+    expect(Array.from(buf)).toEqual([0x61, 0x65, 0x31, 0x36, 0x66, 0x37, 0x38, 0x61]);
   });
 
-  // test('handles non-hexadecimal string input', () => {
-  //   expect(strInsert('7A7Z')).toBe('z\u{FFFD}');
-  // });
+  test('utf8-encodes empty string to empty buffer', () => {
+    expect(messageToBuffer('').length).toBe(0);
+  });
+
+  test('utf8-encodes multi-byte unicode text', () => {
+    const buf = messageToBuffer('你好');
+    expect(Array.from(buf)).toEqual([0xe4, 0xbd, 0xa0, 0xe5, 0xa5, 0xbd]);
+  });
 });

--- a/src/tests/evm_wallet/verify_eth_message_sign.test.ts
+++ b/src/tests/evm_wallet/verify_eth_message_sign.test.ts
@@ -1,3 +1,4 @@
+import { ethers } from 'ethers';
 import { EvmWallet } from '../../evm_wallet';
 
 const DEFAULT_PRIVATE_KEY = '0000000000000000000000000000000000000000000000000000000000000001';
@@ -82,5 +83,37 @@ describe('evm walLet - verifyEthMessageSign', () => {
       DEFAULT_USER_ADDRESS1.slice(2),
     );
     expect(result).toBe(true);
+  });
+});
+
+describe('evm wallet - signMessage EIP-191 interop with ethers', () => {
+  const wallet = new EvmWallet();
+
+  it('plain text signs the UTF-8 bytes of the message', async () => {
+    const message = 'testMessage';
+    const sig = await wallet.signMessage({ privateKey: DEFAULT_PRIVATE_KEY, data: message });
+    const recovered = ethers.utils.verifyMessage(message, sig);
+    expect(recovered.toLowerCase()).toBe(DEFAULT_USER_ADDRESS1.toLowerCase());
+  });
+
+  it('0x-prefixed hex signs the raw decoded bytes', async () => {
+    const message = '0xae16f78a';
+    const sig = await wallet.signMessage({ privateKey: DEFAULT_PRIVATE_KEY, data: message });
+    const recovered = ethers.utils.verifyMessage(ethers.utils.arrayify(message), sig);
+    expect(recovered.toLowerCase()).toBe(DEFAULT_USER_ADDRESS1.toLowerCase());
+  });
+
+  it('bare hex without "0x" signs the UTF-8 bytes of the string', async () => {
+    const message = 'ae16f78a';
+    const sig = await wallet.signMessage({ privateKey: DEFAULT_PRIVATE_KEY, data: message });
+    const recovered = ethers.utils.verifyMessage(message, sig);
+    expect(recovered.toLowerCase()).toBe(DEFAULT_USER_ADDRESS1.toLowerCase());
+  });
+
+  it('0x-prefixed hex with high bytes signs raw bytes (not UTF-8 mojibake)', async () => {
+    const message = '0xdeadbeef';
+    const sig = await wallet.signMessage({ privateKey: DEFAULT_PRIVATE_KEY, data: message });
+    const recovered = ethers.utils.verifyMessage(ethers.utils.arrayify(message), sig);
+    expect(recovered.toLowerCase()).toBe(DEFAULT_USER_ADDRESS1.toLowerCase());
   });
 });


### PR DESCRIPTION
Replace msgHexToText with messageToBuffer so signMessage / verifyEthMessageSign / LedgerEvmSigner consume the same byte semantics as ethers / MetaMask:
- 0x-prefixed input is hex-decoded to raw bytes (left-padded if odd length)
- otherwise the input is taken as UTF-8 text

The old path went hex -> utf8 string -> utf8 bytes, which was lossy for any 0x-hex containing non-UTF-8 bytes (e.g. 0xdeadbeef) and silently dropped a trailing nibble for odd-length hex. Bare hex without 0x is no longer auto-detected as hex; it is signed as plain text, matching MetaMask.

Tests cover both isHexMessage / messageToBuffer and an ethers verifyMessage interop suite across plain text, 0x ASCII hex, bare hex, high-byte hex, and odd-length hex.