### PR TITLE
chore(deps): pin @babel/plugin-transform-modules-systemjs to 7.29.4 via pnpm overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,9 @@
       "qs": "6.14.2",
       "serialize-javascript": "7.0.5",
       "picomatch": "2.3.2",
-      "follow-redirects": "1.16.0"
+      "follow-redirects": "1.16.0",
+      "fast-uri": "3.1.2",
+      "@babel/plugin-transform-modules-systemjs": "7.29.4"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,6 +34,8 @@ overrides:
   serialize-javascript: 7.0.5
   picomatch: 2.3.2
   follow-redirects: 1.16.0
+  fast-uri: 3.1.2
+  '@babel/plugin-transform-modules-systemjs': 7.29.4
 
 importers:
 
@@ -615,8 +617,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-modules-systemjs@7.29.0':
-    resolution: {integrity: sha512-PrujnVFbOdUpw4UHiVwKvKRLMMic8+eC0CuNlxjsyZUiBjhFdPsewdXCkveh2KqBA9/waD0W1b4hXSOBQJezpQ==}
+  '@babel/plugin-transform-modules-systemjs@7.29.4':
+    resolution: {integrity: sha512-N7QmZ0xRZfjHOfZeQLJjwgX2zS9pdGHSVl/cjSGlo4dXMqvurfxXDMKY4RqEKzPozV78VMcd0lxyG13mlbKc4w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2340,8 +2342,8 @@ packages:
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fastest-levenshtein@1.0.16:
     resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
@@ -4582,7 +4584,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-modules-systemjs@7.29.0(@babel/core@7.23.7)':
+  '@babel/plugin-transform-modules-systemjs@7.29.4(@babel/core@7.23.7)':
     dependencies:
       '@babel/core': 7.23.7
       '@babel/helper-module-transforms': 7.28.6(@babel/core@7.23.7)
@@ -4830,7 +4832,7 @@ snapshots:
       '@babel/plugin-transform-member-expression-literals': 7.27.1(@babel/core@7.23.7)
       '@babel/plugin-transform-modules-amd': 7.27.1(@babel/core@7.23.7)
       '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.23.7)
-      '@babel/plugin-transform-modules-systemjs': 7.29.0(@babel/core@7.23.7)
+      '@babel/plugin-transform-modules-systemjs': 7.29.4(@babel/core@7.23.7)
       '@babel/plugin-transform-modules-umd': 7.27.1(@babel/core@7.23.7)
       '@babel/plugin-transform-named-capturing-groups-regex': 7.29.0(@babel/core@7.23.7)
       '@babel/plugin-transform-new-target': 7.27.1(@babel/core@7.23.7)
@@ -6224,7 +6226,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -7090,7 +7092,7 @@ snapshots:
 
   fast-json-stable-stringify@2.1.0: {}
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
   fastest-levenshtein@1.0.16: {}
 


### PR DESCRIPTION
  ## Summary

  - Pin `@babel/plugin-transform-modules-systemjs` to `7.29.4` through `pnpm.overrides` to consume the latest patch and align with the rest of the Babel
  toolchain (other transitive plugins are already at 7.27.x–7.29.x).
  - Also pin `fast-uri` to `3.1.2` via overrides for consistency with neighboring transitive deps.
  - This package is not declared as a direct dependency, so the bump has to go through `pnpm.overrides` — declaring the version in
  `dependencies`/`devDependencies` would have no effect on the resolution path used by `@babel/preset-env`.

  ## Why

  - Keeps the lockfile aligned with the latest patch in the 7.29.x line.
  - No churn in the dependency graph: the upgrade only changes the systemjs entry itself; no new packages are pulled in, no new versions of `@babel/core`,
  `traverse`, `types`, `generator`, `helper-module-transforms`, etc. are introduced.
