### PR TITLE
chore: override shell-quote to 1.8.4 to fix GHSA-w7jw-789q-3m8p

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
       "sha.js": "2.4.12",
       "cipher-base": "1.0.5",
       "node-forge": "1.4.0",
+      "shell-quote": "1.8.4",
       "qs": "6.14.2",
       "serialize-javascript": "7.0.5",
       "picomatch": "2.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,7 @@ overrides:
   sha.js: 2.4.12
   cipher-base: 1.0.5
   node-forge: 1.4.0
+  shell-quote: 1.8.4
   qs: 6.14.2
   serialize-javascript: 7.0.5
   picomatch: 2.3.2
@@ -3540,8 +3541,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.3:
-    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+  shell-quote@1.8.4:
+    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
     engines: {node: '>= 0.4'}
 
   side-channel-list@1.0.0:
@@ -7805,7 +7806,7 @@ snapshots:
   launch-editor@2.13.2:
     dependencies:
       picocolors: 1.1.1
-      shell-quote: 1.8.3
+      shell-quote: 1.8.4
 
   leven@3.1.0: {}
 
@@ -8392,7 +8393,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.3: {}
+  shell-quote@1.8.4: {}
 
   side-channel-list@1.0.0:
     dependencies:


### PR DESCRIPTION
shell-quote <=1.8.3 (critical, CWE-77/78) reached via webpack-dev-server > launch-editor > shell-quote. Dev-only chain, but pin to the patched 1.8.4 to clear the audit critical.