### PR TITLE
fix(evm_wallet): require a positive chainId in buildUnsignedTransaction

### DIFF
--- a/src/evm_wallet/util.ts
+++ b/src/evm_wallet/util.ts
@@ -1,4 +1,6 @@
-import { Transaction } from 'ethers';
+import { Transaction, getBigInt } from 'ethers';
+
+import { InvalidParameterError } from '../base_wallet/error';
 
 const HEX_MESSAGE_REGEX = /^0x[0-9a-fA-F]+$/;
 
@@ -37,11 +39,16 @@ const TX_FIELDS = new Set<string>([
 //   3. Wallet payloads carry extra fields (`from`, `isUserEdit`, …) that v6
 //      rejects on unsigned txs.
 // This helper restores the v5-compatible legacy default, normalizes hex `type`,
-// and strips unknown fields before building the Transaction.
+// and strips unknown fields before building the Transaction. It also rejects a
+// missing or zero chainId: ethers would serialize a pre-EIP-155 payload whose
+// Ledger signature is replayable on every EVM chain.
 export function buildUnsignedTransaction(raw: Record<string, any>): Transaction {
   const out: Record<string, any> = {};
   for (const k of Object.keys(raw)) {
     if (TX_FIELDS.has(k)) out[k] = raw[k];
+  }
+  if (out.chainId == null || getBigInt(out.chainId) <= 0n) {
+    throw new InvalidParameterError('a positive chainId is required (EIP-155 replay protection)');
   }
   if (out.type === undefined) {
     out.type = 0;

--- a/src/tests/evm_wallet/ledger/ledger_sign.test.ts
+++ b/src/tests/evm_wallet/ledger/ledger_sign.test.ts
@@ -34,6 +34,7 @@ describe('evm ledgerSign test', () => {
     const testObjectTransaction = {
       to: DEFAULT_USER_ADDRESS1,
       value: 1111,
+      chainId: 1,
     };
     LedgerEthWebHid.prototype.signPersonalMessage = jest
       .fn()
@@ -46,12 +47,12 @@ describe('evm ledgerSign test', () => {
       data: testObjectTransaction,
       path: testPath,
     });
-    // Hardcoded oracle: legacy unsigned RLP for { to: ADDR1, value: 1111 }
-    // produced by ethers v5 `serializeTransaction`. Locking the bytes here
-    // (rather than recomputing them with the current ethers version) is what
-    // catches the v6-style envelope regression the user surfaced.
+    // Hardcoded oracle: legacy unsigned RLP for { to: ADDR1, value: 1111, chainId: 1 }
+    // with the EIP-155 [chainId, 0, 0] trailer. Locking the bytes here (rather than
+    // recomputing them with the current ethers version) is what catches the
+    // v6-style envelope regression the user surfaced.
     const expectedSerialized =
-      'dc808080947e5f4552091a69125d5dfcb7b8c2659029395bdf82045780';
+      'df808080947e5f4552091a69125d5dfcb7b8c2659029395bdf82045780018080';
     expect(ledgerWebHid.signTransaction).toHaveBeenCalledWith(expectedSerialized, testPath);
   });
 
@@ -60,12 +61,13 @@ describe('evm ledgerSign test', () => {
     const testObjectTransaction = {
       to: DEFAULT_USER_ADDRESS1,
       value: 1111,
+      chainId: 1,
     };
     LedgerEthWebHid.prototype.signTransaction = jest
       .fn()
       .mockRejectedValue(new SignError('testSignError'));
 
-    expect(
+    await expect(
       ledgerEvmSigner.ledgerSign({
         data: testObjectTransaction,
         path: testPath,

--- a/src/tests/evm_wallet/util.test.ts
+++ b/src/tests/evm_wallet/util.test.ts
@@ -1,3 +1,4 @@
+import { InvalidParameterError } from '../../base_wallet/error';
 import { buildUnsignedTransaction, isHexMessage, messageToBuffer } from '../../evm_wallet/util';
 
 describe('isHexMessage', () => {
@@ -159,5 +160,17 @@ describe('buildUnsignedTransaction', () => {
     expect(() =>
       buildUnsignedTransaction({ to: TO, value: '0x1', chainId: 1, type: 'abc' }),
     ).toThrow();
+  });
+
+  // chainId guard: without it ethers serializes a pre-EIP-155 payload and a
+  // Ledger signature over it is replayable on every EVM chain.
+  test('throws InvalidParameterError when chainId is missing', () => {
+    expect(() => buildUnsignedTransaction({ to: TO, value: '0x1' })).toThrow(InvalidParameterError);
+  });
+
+  test.each([0, '0x0'])('throws InvalidParameterError when chainId is %p', chainId => {
+    expect(() => buildUnsignedTransaction({ to: TO, value: '0x1', chainId })).toThrow(
+      InvalidParameterError,
+    );
   });
 });


### PR DESCRIPTION
Without chainId ethers defaults it to 0 and serializes a pre-EIP-155 legacy payload (no [chainId, 0, 0] trailer); hw-app-eth then returns a bare v=27/28, so a Ledger signature is replayable on every EVM chain (CWE-294). verifyEthTransactionSign shares the same construction path and could not catch the omission.

buildUnsignedTransaction now throws InvalidParameterError when chainId is missing, zero, or negative, covering both the Ledger signing and the verification paths. Unparseable values keep failing via ethers' getBigInt.

The ledger_sign tests had locked the vulnerable pre-EIP-155 bytes as their hardcoded oracle; the fixtures now carry chainId 1 with the EIP-155 serialization, and the missing await on the rejects assertion (which crashed the jest worker) is fixed.