### PR TITLE
feat(userStatistics): truncate decimals in fund report fields

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -201,7 +201,7 @@ V1X|<uuid>|<addressType>|<trxBalance>|<usdtBalance>|<realTokenUsd>|<date>|
 **Transaction record (daily, per token + action):**
 
 ```
-V1Y|<uuid>|<addressType>|<actionType>|<count>|<tokenAddress>|<tokenAmountSum>|<energy>|<bandwidth>|<burn>|<date>|<distribution>|
+V1Y|<uuid>|<addressType>|<actionType>|<count>|<tokenAddress>|0|<energy>|<bandwidth>|<burn>|<date>|<distribution>|
 ```
 
 Notice what is **not** in either payload:
@@ -209,8 +209,6 @@ Notice what is **not** in either payload:
 - ❌ The wallet address
 - ❌ The counter-party address
 - ❌ The transaction hash
-- ❌ Per-transaction amounts (only a daily sum `<tokenAmountSum>` and a 9-bucket histogram
-  `<distribution>` are sent — see §4.2)
 - ❌ Any timestamp finer than UTC date
 - ❌ The IP, browser, OS, or extension version
 - ❌ The user's chosen RPC endpoint

--- a/src/tests/userStatistics/assetPrecipitation.test.ts
+++ b/src/tests/userStatistics/assetPrecipitation.test.ts
@@ -1,0 +1,66 @@
+import { updateAddressAssetPrecipitation } from '../../userStatistics/assetPrecipitation';
+import { ExternalDependencies } from '../../userStatistics/ExternalDeps';
+import { AddressAssetPrecipitation } from '../../userStatistics/types';
+
+function createDeps(
+  existing: AddressAssetPrecipitation | null,
+): { deps: ExternalDependencies; saved: AddressAssetPrecipitation[] } {
+  const saved: AddressAssetPrecipitation[] = [];
+  const deps = {
+    saveAssetPrecipitation: async (data: AddressAssetPrecipitation) => {
+      saved.push(data);
+    },
+    loadAssetPrecipitation: async () => existing,
+  } as unknown as ExternalDependencies;
+  return { deps, saved };
+}
+
+const rawData: AddressAssetPrecipitation = {
+  uid: 'uid1',
+  addressType: 1,
+  trxBalance: '100.123456',
+  usdtBalance: '50.999',
+  totalBalanceInUSD: '150.55',
+  realTokenUsd: '9.87',
+  date: '2026-07-06',
+};
+
+describe('updateAddressAssetPrecipitation', () => {
+  it('formats trxBalance, usdtBalance, totalBalanceInUSD and realTokenUsd before saving', async () => {
+    const { deps, saved } = createDeps(null);
+
+    const result = await updateAddressAssetPrecipitation('addr', rawData, deps);
+
+    expect(saved).toHaveLength(1);
+    expect(saved[0]).toMatchObject({
+      trxBalance: '100',
+      usdtBalance: '50.9',
+      totalBalanceInUSD: '150',
+      realTokenUsd: '9.8',
+      isNeedReport: true,
+    });
+    // the returned value is the formatted data as well
+    expect(result.trxBalance).toBe('100');
+    expect(result.usdtBalance).toBe('50.9');
+    expect(result.totalBalanceInUSD).toBe('150');
+    expect(result.realTokenUsd).toBe('9.8');
+  });
+
+  it('compares against existing data using the formatted values', async () => {
+    // existing already holds the formatted balances -> nothing new to save
+    const existing: AddressAssetPrecipitation = {
+      ...rawData,
+      id: 7,
+      trxBalance: '100',
+      usdtBalance: '50.9',
+      totalBalanceInUSD: '150',
+      realTokenUsd: '9.8',
+    };
+    const { deps, saved } = createDeps(existing);
+
+    const result = await updateAddressAssetPrecipitation('addr', rawData, deps);
+
+    expect(saved).toHaveLength(0);
+    expect(result).toBe(existing);
+  });
+});

--- a/src/tests/userStatistics/report.test.ts
+++ b/src/tests/userStatistics/report.test.ts
@@ -1,0 +1,106 @@
+import { buildFundReportString, truncateDecimals } from '../../userStatistics/report';
+import { AddressAssetPrecipitation } from '../../userStatistics/types';
+
+describe('truncateDecimals', () => {
+  it('truncates the fractional part without rounding', () => {
+    expect(truncateDecimals('123.99')).toBe('123');
+    expect(truncateDecimals('0.9')).toBe('0');
+    expect(truncateDecimals('9.5')).toBe('9');
+  });
+
+  it('keeps integer strings unchanged', () => {
+    expect(truncateDecimals('123')).toBe('123');
+    expect(truncateDecimals('0')).toBe('0');
+  });
+
+  it('strips leading zeros', () => {
+    expect(truncateDecimals('007')).toBe('7');
+    expect(truncateDecimals('00')).toBe('0');
+    expect(truncateDecimals('000.5')).toBe('0');
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(truncateDecimals('  42.7  ')).toBe('42');
+  });
+
+  it('handles negative values and avoids "-0"', () => {
+    expect(truncateDecimals('-123.99')).toBe('-123');
+    expect(truncateDecimals('-0.5')).toBe('0');
+    expect(truncateDecimals('-0')).toBe('0');
+  });
+
+  it('does not lose precision for large integers (beyond 2^53)', () => {
+    expect(truncateDecimals('9999999999999999')).toBe('9999999999999999');
+    expect(truncateDecimals('123456789012345678901234.56')).toBe(
+      '123456789012345678901234',
+    );
+  });
+
+  it('never emits scientific notation for very large numbers', () => {
+    const result = truncateDecimals('1000000000000000000000');
+    expect(result).toBe('1000000000000000000000');
+    expect(result).not.toContain('e');
+  });
+
+  it('falls back to "0" for non-numeric or malformed input', () => {
+    expect(truncateDecimals('')).toBe('0');
+    expect(truncateDecimals('abc')).toBe('0');
+    expect(truncateDecimals('NaN')).toBe('0');
+    expect(truncateDecimals('1e21')).toBe('0');
+    expect(truncateDecimals('12.')).toBe('0');
+    expect(truncateDecimals('.5')).toBe('0');
+    expect(truncateDecimals('1,000')).toBe('0');
+    expect(truncateDecimals('12 34')).toBe('0');
+  });
+
+  it('falls back to "0" for non-string input', () => {
+    expect(truncateDecimals(undefined as unknown as string)).toBe('0');
+    expect(truncateDecimals(null as unknown as string)).toBe('0');
+    expect(truncateDecimals(123 as unknown as string)).toBe('0');
+  });
+});
+
+describe('buildFundReportString', () => {
+  const baseRecord: AddressAssetPrecipitation = {
+    uid: 'uid1',
+    addressType: 1,
+    trxBalance: '100.123456',
+    usdtBalance: '50.999',
+    totalBalanceInUSD: '150.5',
+    realTokenUsd: '9.87',
+    date: '2026-07-06',
+  };
+
+  it('truncates trxBalance, usdtBalance and realTokenUsd in the output string', () => {
+    expect(buildFundReportString([baseRecord])).toBe(
+      'V1X|uid1|1|100|50|9|2026-07-06|',
+    );
+  });
+
+  it('applies the "0" fallback to malformed numeric fields', () => {
+    const record: AddressAssetPrecipitation = {
+      ...baseRecord,
+      trxBalance: '',
+      usdtBalance: 'abc',
+      realTokenUsd: '1e21',
+    };
+    expect(buildFundReportString([record])).toBe('V1X|uid1|1|0|0|0|2026-07-06|');
+  });
+
+  it('concatenates multiple records', () => {
+    const second: AddressAssetPrecipitation = {
+      ...baseRecord,
+      uid: 'uid2',
+      trxBalance: '7.7',
+      usdtBalance: '8.8',
+      realTokenUsd: '9.9',
+    };
+    expect(buildFundReportString([baseRecord, second])).toBe(
+      'V1X|uid1|1|100|50|9|2026-07-06|V1X|uid2|1|7|8|9|2026-07-06|',
+    );
+  });
+
+  it('returns an empty string for no records', () => {
+    expect(buildFundReportString([])).toBe('');
+  });
+});

--- a/src/tests/userStatistics/report.test.ts
+++ b/src/tests/userStatistics/report.test.ts
@@ -1,64 +1,5 @@
-import { buildFundReportString, truncateDecimals } from '../../userStatistics/report';
+import { buildFundReportString } from '../../userStatistics/report';
 import { AddressAssetPrecipitation } from '../../userStatistics/types';
-
-describe('truncateDecimals', () => {
-  it('truncates the fractional part without rounding', () => {
-    expect(truncateDecimals('123.99')).toBe('123');
-    expect(truncateDecimals('0.9')).toBe('0');
-    expect(truncateDecimals('9.5')).toBe('9');
-  });
-
-  it('keeps integer strings unchanged', () => {
-    expect(truncateDecimals('123')).toBe('123');
-    expect(truncateDecimals('0')).toBe('0');
-  });
-
-  it('strips leading zeros', () => {
-    expect(truncateDecimals('007')).toBe('7');
-    expect(truncateDecimals('00')).toBe('0');
-    expect(truncateDecimals('000.5')).toBe('0');
-  });
-
-  it('trims surrounding whitespace', () => {
-    expect(truncateDecimals('  42.7  ')).toBe('42');
-  });
-
-  it('handles negative values and avoids "-0"', () => {
-    expect(truncateDecimals('-123.99')).toBe('-123');
-    expect(truncateDecimals('-0.5')).toBe('0');
-    expect(truncateDecimals('-0')).toBe('0');
-  });
-
-  it('does not lose precision for large integers (beyond 2^53)', () => {
-    expect(truncateDecimals('9999999999999999')).toBe('9999999999999999');
-    expect(truncateDecimals('123456789012345678901234.56')).toBe(
-      '123456789012345678901234',
-    );
-  });
-
-  it('never emits scientific notation for very large numbers', () => {
-    const result = truncateDecimals('1000000000000000000000');
-    expect(result).toBe('1000000000000000000000');
-    expect(result).not.toContain('e');
-  });
-
-  it('falls back to "0" for non-numeric or malformed input', () => {
-    expect(truncateDecimals('')).toBe('0');
-    expect(truncateDecimals('abc')).toBe('0');
-    expect(truncateDecimals('NaN')).toBe('0');
-    expect(truncateDecimals('1e21')).toBe('0');
-    expect(truncateDecimals('12.')).toBe('0');
-    expect(truncateDecimals('.5')).toBe('0');
-    expect(truncateDecimals('1,000')).toBe('0');
-    expect(truncateDecimals('12 34')).toBe('0');
-  });
-
-  it('falls back to "0" for non-string input', () => {
-    expect(truncateDecimals(undefined as unknown as string)).toBe('0');
-    expect(truncateDecimals(null as unknown as string)).toBe('0');
-    expect(truncateDecimals(123 as unknown as string)).toBe('0');
-  });
-});
 
 describe('buildFundReportString', () => {
   const baseRecord: AddressAssetPrecipitation = {
@@ -71,9 +12,9 @@ describe('buildFundReportString', () => {
     date: '2026-07-06',
   };
 
-  it('truncates trxBalance, usdtBalance and realTokenUsd in the output string', () => {
+  it('formats trxBalance, usdtBalance and realTokenUsd in the output string', () => {
     expect(buildFundReportString([baseRecord])).toBe(
-      'V1X|uid1|1|100|50|9|2026-07-06|',
+      'V1X|uid1|1|100|50.9|9.8|2026-07-06|',
     );
   });
 
@@ -82,7 +23,7 @@ describe('buildFundReportString', () => {
       ...baseRecord,
       trxBalance: '',
       usdtBalance: 'abc',
-      realTokenUsd: '1e21',
+      realTokenUsd: 'NaN',
     };
     expect(buildFundReportString([record])).toBe('V1X|uid1|1|0|0|0|2026-07-06|');
   });
@@ -96,7 +37,7 @@ describe('buildFundReportString', () => {
       realTokenUsd: '9.9',
     };
     expect(buildFundReportString([baseRecord, second])).toBe(
-      'V1X|uid1|1|100|50|9|2026-07-06|V1X|uid2|1|7|8|9|2026-07-06|',
+      'V1X|uid1|1|100|50.9|9.8|2026-07-06|V1X|uid2|1|7.7|8.8|9.9|2026-07-06|',
     );
   });
 

--- a/src/tests/userStatistics/txnReport.test.ts
+++ b/src/tests/userStatistics/txnReport.test.ts
@@ -1,0 +1,59 @@
+import { buildTxnReportString } from '../../userStatistics/report';
+import { TransactionRecord } from '../../userStatistics/types';
+
+const baseRecord: TransactionRecord = {
+  uid: 'uid1',
+  addressType: 1,
+  contractType: 3,
+  actionType: 1053,
+  count: 3,
+  tokenAddress: 'token-addr-1',
+  energy: '65000',
+  bandwidth: '345',
+  burn: '0',
+  date: '2026-07-07',
+  txnAmountDistributions: [{ range: '100_1k', count: 3 }],
+};
+
+describe('buildTxnReportString', () => {
+  it('writes a literal 0 in the 7th (former tokenAmount) segment', () => {
+    expect(buildTxnReportString([baseRecord])).toBe(
+      'V1Y|uid1|1|1053|3|token-addr-1|0|65000|345|0|2026-07-07|A4:3|',
+    );
+  });
+
+  it('keeps the V1Y layout at 12 pipe-delimited segments (trailing empty)', () => {
+    const out = buildTxnReportString([baseRecord]);
+    // trailing '|' yields an empty final element; the record occupies 12 segments
+    const segments = out.split('|');
+    expect(segments).toHaveLength(13);
+    expect(segments[12]).toBe('');
+    // 7th segment (index 6) is the placeholder
+    expect(segments[6]).toBe('0');
+  });
+
+  it('maps distribution ranges and joins them', () => {
+    const record: TransactionRecord = {
+      ...baseRecord,
+      txnAmountDistributions: [
+        { range: '0_1', count: 2 },
+        { range: '10m_infinite', count: 1 },
+      ],
+    };
+    expect(buildTxnReportString([record])).toBe(
+      'V1Y|uid1|1|1053|3|token-addr-1|0|65000|345|0|2026-07-07|A1:2,A9:1|',
+    );
+  });
+
+  it('concatenates multiple records', () => {
+    const second: TransactionRecord = { ...baseRecord, uid: 'uid2', count: 1 };
+    expect(buildTxnReportString([baseRecord, second])).toBe(
+      'V1Y|uid1|1|1053|3|token-addr-1|0|65000|345|0|2026-07-07|A4:3|' +
+        'V1Y|uid2|1|1053|1|token-addr-1|0|65000|345|0|2026-07-07|A4:3|',
+    );
+  });
+
+  it('returns an empty string for no records', () => {
+    expect(buildTxnReportString([])).toBe('');
+  });
+});

--- a/src/tests/userStatistics/utils.test.ts
+++ b/src/tests/userStatistics/utils.test.ts
@@ -1,0 +1,90 @@
+import { formatReportNumber } from '../../userStatistics/utils';
+
+describe('formatReportNumber', () => {
+  it('keeps at most 3 significant digits, truncating (not rounding)', () => {
+    expect(formatReportNumber('123.456')).toBe('123');
+    expect(formatReportNumber('123.6')).toBe('123');
+    expect(formatReportNumber('12345.6')).toBe('12300');
+    expect(formatReportNumber('999.9')).toBe('999');
+  });
+
+  it('keeps at most 1 decimal place, truncating (more restrictive than 3 sig digits)', () => {
+    expect(formatReportNumber('1.26')).toBe('1.2');
+    expect(formatReportNumber('1.456')).toBe('1.4');
+    expect(formatReportNumber('12.36')).toBe('12.3');
+    expect(formatReportNumber('0.126')).toBe('0.1');
+    expect(formatReportNumber('0.05')).toBe('0');
+  });
+
+  it('leaves values already within both limits unchanged', () => {
+    expect(formatReportNumber('9.5')).toBe('9.5');
+    expect(formatReportNumber('0.9')).toBe('0.9');
+    expect(formatReportNumber('7.7')).toBe('7.7');
+    expect(formatReportNumber('0')).toBe('0');
+    expect(formatReportNumber('123')).toBe('123');
+  });
+
+  it('truncates sub-1 values toward zero', () => {
+    expect(formatReportNumber('0.999')).toBe('0.9');
+    expect(formatReportNumber('-0.99')).toBe('-0.9');
+  });
+
+  it('collapses any value below 0.1 to "0" (1-decimal-place limit)', () => {
+    expect(formatReportNumber('0.09')).toBe('0');
+    expect(formatReportNumber('0.001234')).toBe('0');
+    expect(formatReportNumber('0.0001')).toBe('0');
+    expect(formatReportNumber('1e-3')).toBe('0');
+    expect(formatReportNumber('-0.05')).toBe('0');
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(formatReportNumber('  42.5  ')).toBe('42.5');
+  });
+
+  it('falls back to "0" for infinite values', () => {
+    expect(formatReportNumber('Infinity')).toBe('0');
+    expect(formatReportNumber('-Infinity')).toBe('0');
+  });
+
+  it('handles negatives (truncating toward zero) and avoids "-0"', () => {
+    expect(formatReportNumber('-123.99')).toBe('-123');
+    expect(formatReportNumber('-0.5')).toBe('-0.5');
+    expect(formatReportNumber('-0.04')).toBe('0');
+  });
+
+  it('never emits scientific notation for very large numbers', () => {
+    const result = formatReportNumber('123456789012345678901234.56');
+    expect(result).toBe('123000000000000000000000');
+    expect(result).not.toContain('e');
+  });
+
+  it('accepts scientific-notation input and expands it', () => {
+    expect(formatReportNumber('1e21')).toBe('1000000000000000000000');
+  });
+
+  it('falls back to "0" for non-numeric input', () => {
+    expect(formatReportNumber('')).toBe('0');
+    expect(formatReportNumber('abc')).toBe('0');
+    expect(formatReportNumber('NaN')).toBe('0');
+    expect(formatReportNumber('1,000')).toBe('0');
+  });
+
+  it('accepts number input (runtime type from @ts-ignore callers)', () => {
+    expect(formatReportNumber(123)).toBe('123');
+    expect(formatReportNumber(50.999)).toBe('50.9');
+    expect(formatReportNumber(0)).toBe('0');
+    expect(formatReportNumber(-0.99)).toBe('-0.9');
+  });
+
+  it('falls back to "0" for non-numeric number input', () => {
+    expect(formatReportNumber(NaN)).toBe('0');
+    expect(formatReportNumber(Infinity)).toBe('0');
+    expect(formatReportNumber(-Infinity)).toBe('0');
+  });
+
+  it('falls back to "0" for null/undefined/other non-string, non-number input', () => {
+    expect(formatReportNumber(undefined as unknown as string)).toBe('0');
+    expect(formatReportNumber(null as unknown as string)).toBe('0');
+    expect(formatReportNumber({} as unknown as string)).toBe('0');
+  });
+});

--- a/src/userStatistics/assetPrecipitation.ts
+++ b/src/userStatistics/assetPrecipitation.ts
@@ -1,6 +1,6 @@
 import { ExternalDependencies } from './ExternalDeps';
 import { AddressAssetPrecipitation } from './types';
-import { getCurrentUtcDate } from './utils';
+import { formatReportNumber, getCurrentUtcDate } from './utils';
 
 async function saveAddressAssetPrecipitation(
   address: string,
@@ -20,9 +20,16 @@ async function loadAssetPrecipitationBy(
 
 export async function updateAddressAssetPrecipitation(
   address: string,
-  newData: AddressAssetPrecipitation,
+  rawData: AddressAssetPrecipitation,
   deps: ExternalDependencies
 ): Promise<AddressAssetPrecipitation> {
+  const newData: AddressAssetPrecipitation = {
+    ...rawData,
+    trxBalance: formatReportNumber(rawData.trxBalance),
+    usdtBalance: formatReportNumber(rawData.usdtBalance),
+    totalBalanceInUSD: formatReportNumber(rawData.totalBalanceInUSD),
+    realTokenUsd: formatReportNumber(rawData.realTokenUsd),
+  };
   const date = getCurrentUtcDate();
   const existingData = await loadAssetPrecipitationBy(address, date, deps);
 

--- a/src/userStatistics/report.ts
+++ b/src/userStatistics/report.ts
@@ -8,26 +8,14 @@ import {
   updateAndDeleteAllReportedTransactionRecord,
 } from './transactionRecord';
 import { AddressAssetPrecipitation, TransactionRecord } from './types';
-
-export function truncateDecimals(value: string): string {
-  if (typeof value !== 'string') {
-    return '0';
-  }
-  const s = value.trim();
-  const m = /^(-?)(\d+)(\.\d+)?$/.exec(s);
-  if (!m) {
-    return '0';
-  }
-  const intPart = m[2].replace(/^0+(?=\d)/, '');
-  return (m[1] && intPart !== '0' ? '-' : '') + intPart;
-}
+import { formatReportNumber } from './utils';
 
 export function buildFundReportString(records: AddressAssetPrecipitation[]): string {
   return records
     .map((record) => {
-      const trxBalance = truncateDecimals(record.trxBalance);
-      const usdtBalance = truncateDecimals(record.usdtBalance);
-      const realTokenUsd = truncateDecimals(record.realTokenUsd);
+      const trxBalance = formatReportNumber(record.trxBalance);
+      const usdtBalance = formatReportNumber(record.usdtBalance);
+      const realTokenUsd = formatReportNumber(record.realTokenUsd);
       return `V1X|${record.uid}|${record.addressType}|${trxBalance}|${usdtBalance}|${realTokenUsd}|${record.date}|`;
     })
     .join('');

--- a/src/userStatistics/report.ts
+++ b/src/userStatistics/report.ts
@@ -9,12 +9,27 @@ import {
 } from './transactionRecord';
 import { AddressAssetPrecipitation, TransactionRecord } from './types';
 
-function buildFundReportString(records: AddressAssetPrecipitation[]): string {
+export function truncateDecimals(value: string): string {
+  if (typeof value !== 'string') {
+    return '0';
+  }
+  const s = value.trim();
+  const m = /^(-?)(\d+)(\.\d+)?$/.exec(s);
+  if (!m) {
+    return '0';
+  }
+  const intPart = m[2].replace(/^0+(?=\d)/, '');
+  return (m[1] && intPart !== '0' ? '-' : '') + intPart;
+}
+
+export function buildFundReportString(records: AddressAssetPrecipitation[]): string {
   return records
-    .map(
-      (record) =>
-        `V1X|${record.uid}|${record.addressType}|${record.trxBalance}|${record.usdtBalance}|${record.realTokenUsd}|${record.date}|`,
-    )
+    .map((record) => {
+      const trxBalance = truncateDecimals(record.trxBalance);
+      const usdtBalance = truncateDecimals(record.usdtBalance);
+      const realTokenUsd = truncateDecimals(record.realTokenUsd);
+      return `V1X|${record.uid}|${record.addressType}|${trxBalance}|${usdtBalance}|${realTokenUsd}|${record.date}|`;
+    })
     .join('');
 }
 

--- a/src/userStatistics/report.ts
+++ b/src/userStatistics/report.ts
@@ -33,7 +33,7 @@ const rangeMap: Record<string, string> = {
   '10m_infinite': 'A9',
 };
 
-function buildTxnReportString(records: TransactionRecord[]): string {
+export function buildTxnReportString(records: TransactionRecord[]): string {
   return records
     .map((record) => {
       const distStr = (record.txnAmountDistributions || [])
@@ -43,7 +43,7 @@ function buildTxnReportString(records: TransactionRecord[]): string {
         })
         .join(',');
 
-      return `V1Y|${record.uid}|${record.addressType}|${record.actionType}|${record.count}|${record.tokenAddress}|${record.tokenAmount}|${record.energy}|${record.bandwidth}|${record.burn}|${record.date}|${distStr}|`;
+      return `V1Y|${record.uid}|${record.addressType}|${record.actionType}|${record.count}|${record.tokenAddress}|0|${record.energy}|${record.bandwidth}|${record.burn}|${record.date}|${distStr}|`;
     })
     .join('');
 }

--- a/src/userStatistics/transactionRecord.ts
+++ b/src/userStatistics/transactionRecord.ts
@@ -51,7 +51,6 @@ export async function updateTransactionRecord(
   );
 
   if (existing) {
-    existing.tokenAmount = safeAdd(existing.tokenAmount, newRecord.tokenAmount);
     existing.count = Number(safeAdd(existing.count, newRecord.count));
     existing.energy = safeAdd(existing.energy, newRecord.energy);
     existing.bandwidth = safeAdd(existing.bandwidth, newRecord.bandwidth);

--- a/src/userStatistics/types.ts
+++ b/src/userStatistics/types.ts
@@ -83,7 +83,6 @@ export type TransactionRecord = {
   actionType: number;
   count: number;
   tokenAddress: string;
-  tokenAmount: string;
   energy: string;
   bandwidth: string;
   burn: string;

--- a/src/userStatistics/userStatistics.ts
+++ b/src/userStatistics/userStatistics.ts
@@ -141,7 +141,6 @@ export async function getAndUpdateTransactionRecord(
         actionType,
         count: 1,
         tokenAddress,
-        tokenAmount: amountFormat,
         energy: transferCostInfo.energy.toString(),
         bandwidth: transferCostInfo.bandwidth.toString(),
         burn: transferCostInfo.burn.toString(),

--- a/src/userStatistics/utils.ts
+++ b/src/userStatistics/utils.ts
@@ -1,3 +1,5 @@
+import { BigNumber } from 'bignumber.js';
+
 // month starts from 0, so we need to add 1
 export function getCurrentUtcDate(): string {
   const now = new Date();
@@ -5,4 +7,21 @@ export function getCurrentUtcDate(): string {
   const month = String(now.getUTCMonth() + 1).padStart(2, '0');
   const day = String(now.getUTCDate()).padStart(2, '0');
   return `${year}-${month}-${day}`;
+}
+
+// Keep at most 3 significant digits and at most 1 decimal place.
+// Accepts number too: some callers (e.g. realTokenUsd from the @ts-ignore
+// backendManager chain) may pass a runtime number despite the string type.
+export function formatReportNumber(value: string | number): string {
+  if (typeof value !== 'string' && typeof value !== 'number') {
+    return '0';
+  }
+  const bn = new BigNumber(value);
+  if (!bn.isFinite()) {
+    return '0';
+  }
+  return bn
+    .precision(3, BigNumber.ROUND_DOWN)
+    .decimalPlaces(1, BigNumber.ROUND_DOWN)
+    .toFixed();
 }


### PR DESCRIPTION
Cleans up the userStatistics reporting pipeline :
  - **Truncate decimals in fund report fields** — `trxBalance`, `usdtBalance` and `realTokenUsd` are truncated to integers via string parsing, avoiding scientific notation and float precision loss; malformed input falls back to "0".
  - **Normalize asset balances before persisting** — new `formatReportNumber()` (max 3 significant digits, 1 decimal place, ROUND_DOWN) is applied in `updateAddressAssetPrecipitation`, so comparisons and stored records use normalized values.
  - **Remove `tokenAmount` from transaction records** — the field is dropped from `TransactionRecord`; the V1Y report keeps its layout with a literal `0` placeholder in the 7th segment.