### PR TITLE
Release/1.1.1

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -201,7 +201,7 @@ V1X|<uuid>|<addressType>|<trxBalance>|<usdtBalance>|<realTokenUsd>|<date>|
 **Transaction record (daily, per token + action):**
 
 ```
-V1Y|<uuid>|<addressType>|<actionType>|<count>|<tokenAddress>|<tokenAmountSum>|<energy>|<bandwidth>|<burn>|<date>|<distribution>|
+V1Y|<uuid>|<addressType>|<actionType>|<count>|<tokenAddress>|0|<energy>|<bandwidth>|<burn>|<date>|<distribution>|
 ```
 
 Notice what is **not** in either payload:
@@ -209,8 +209,6 @@ Notice what is **not** in either payload:
 - ❌ The wallet address
 - ❌ The counter-party address
 - ❌ The transaction hash
-- ❌ Per-transaction amounts (only a daily sum `<tokenAmountSum>` and a 9-bucket histogram
-  `<distribution>` are sent — see §4.2)
 - ❌ Any timestamp finer than UTC date
 - ❌ The IP, browser, OS, or extension version
 - ❌ The user's chosen RPC endpoint

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tronlink/core",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "The library serves as a core module within TronLink Extension, which provides low-level wallet functionality for both Tron and Ethereum networks, primary features includes account generation and transaction signing",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "typescript": "5.8.3",
     "webpack": "5.104.1",
     "webpack-cli": "5.1.4",
-    "webpack-dev-server": "5.2.4",
+    "webpack-dev-server": "5.2.5",
     "webpack-merge": "5.8.0",
     "webpack-node-externals": "3.0.0"
   },
@@ -94,7 +94,7 @@
       "express": "4.20.0",
       "send": "0.19.0",
       "secp256k1": "4.0.4",
-      "http-proxy-middleware": "2.0.9",
+      "http-proxy-middleware": "2.0.10",
       "cookie": "0.7.0",
       "cross-spawn": "7.0.5",
       "path-to-regexp@<0.1.13": "0.1.13",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ overrides:
   express: 4.20.0
   send: 0.19.0
   secp256k1: 4.0.4
-  http-proxy-middleware: 2.0.9
+  http-proxy-middleware: 2.0.10
   cookie: 0.7.0
   cross-spawn: 7.0.5
   path-to-regexp@<0.1.13: 0.1.13
@@ -192,10 +192,10 @@ importers:
         version: 5.104.1(webpack-cli@5.1.4)
       webpack-cli:
         specifier: 5.1.4
-        version: 5.1.4(webpack-dev-server@5.2.4)(webpack@5.104.1)
+        version: 5.1.4(webpack-dev-server@5.2.5)(webpack@5.104.1)
       webpack-dev-server:
-        specifier: 5.2.4
-        version: 5.2.4(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.104.1)
+        specifier: 5.2.5
+        version: 5.2.5(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.104.1)
       webpack-merge:
         specifier: 5.8.0
         version: 5.8.0
@@ -216,20 +216,32 @@ packages:
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/compat-data@7.29.0':
     resolution: {integrity: sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@7.29.7':
+    resolution: {integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/core@7.23.7':
     resolution: {integrity: sha512-+UpDgowcmqe36d4NwqvKsyPMlOLNGMsfMmQ5WGCu+siCe3t3dfe9njrzGfdN4qq+bcNUt0+Vw6haRxBOycs4dw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/core@7.29.0':
-    resolution: {integrity: sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==}
+  '@babel/core@7.29.7':
+    resolution: {integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/generator@7.29.1':
     resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.7':
+    resolution: {integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-annotate-as-pure@7.27.3':
@@ -238,6 +250,10 @@ packages:
 
   '@babel/helper-compilation-targets@7.28.6':
     resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.29.7':
+    resolution: {integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-create-class-features-plugin@7.28.6':
@@ -279,6 +295,10 @@ packages:
     resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-globals@7.29.7':
+    resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-member-expression-to-functions@7.28.5':
     resolution: {integrity: sha512-cwM7SBRZcPCLgl8a7cY0soT1SptSzAlMH39vwiRpOQkJlh53r5hdHwLSCZpQdVLT39sZt+CRpNwYG4Y2v77atg==}
     engines: {node: '>=6.9.0'}
@@ -287,8 +307,18 @@ packages:
     resolution: {integrity: sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-module-imports@7.29.7':
+    resolution: {integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-module-transforms@7.28.6':
     resolution: {integrity: sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-module-transforms@7.29.7':
+    resolution: {integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -325,12 +355,24 @@ packages:
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-identifier@7.28.5':
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-option@7.27.1':
     resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-option@7.29.7':
+    resolution: {integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-wrap-function@7.28.6':
@@ -343,6 +385,11 @@ packages:
 
   '@babel/parser@7.29.2':
     resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/parser@7.29.7':
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -824,12 +871,24 @@ packages:
     resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/template@7.29.7':
+    resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/traverse@7.29.0':
     resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/traverse@7.29.7':
+    resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.7':
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
 
   '@bcoe/v8-coverage@0.2.3':
@@ -2483,8 +2542,8 @@ packages:
   http-parser-js@0.5.10:
     resolution: {integrity: sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==}
 
-  http-proxy-middleware@2.0.9:
-    resolution: {integrity: sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==}
+  http-proxy-middleware@2.0.10:
+    resolution: {integrity: sha512-RKzRWNPxUZqbuk3BC5mGVJbBnWgr+diEnjJexIOytFbBzDy88Fbh/YvBr3DsNrl1jYAfjWfpATEv0NO35FDuPQ==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
       '@types/express': ^4.17.13
@@ -3851,8 +3910,8 @@ packages:
       webpack:
         optional: true
 
-  webpack-dev-server@5.2.4:
-    resolution: {integrity: sha512-GqDPGZN9bRqKBTkp4aWkobDDHMsrXKoGSdOH56smIri8qR0JG8gfL8/v/f/OZR3/OKXjG8uwJbFVhKm/FNU/UA==}
+  webpack-dev-server@5.2.5:
+    resolution: {integrity: sha512-4wZtCquSuv9CKX8oybo+mqxtxZqWz47uM1Ch94lxowBztOhWCbhqvRbfC/mODOwxgV2brY+JGZpHq58/SuVFYg==}
     engines: {node: '>= 18.12.0'}
     hasBin: true
     peerDependencies:
@@ -3977,20 +4036,28 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
+  '@babel/code-frame@7.29.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
   '@babel/compat-data@7.29.0': {}
+
+  '@babel/compat-data@7.29.7': {}
 
   '@babel/core@7.23.7':
     dependencies:
       '@ampproject/remapping': 2.3.0
-      '@babel/code-frame': 7.29.0
-      '@babel/generator': 7.29.1
-      '@babel/helper-compilation-targets': 7.28.6
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.23.7)
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.23.7)
       '@babel/helpers': 7.26.10
-      '@babel/parser': 7.29.2
-      '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
       convert-source-map: 2.0.0
       debug: 4.4.3
       gensync: 1.0.0-beta.2
@@ -3999,17 +4066,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/core@7.29.0':
+  '@babel/core@7.29.7':
     dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/generator': 7.29.1
-      '@babel/helper-compilation-targets': 7.28.6
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
       '@babel/helpers': 7.26.10
-      '@babel/parser': 7.29.2
-      '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
       debug: 4.4.3
@@ -4027,6 +4094,14 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
 
+  '@babel/generator@7.29.7':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
   '@babel/helper-annotate-as-pure@7.27.3':
     dependencies:
       '@babel/types': 7.29.0
@@ -4035,6 +4110,14 @@ snapshots:
     dependencies:
       '@babel/compat-data': 7.29.0
       '@babel/helper-validator-option': 7.27.1
+      browserslist: 4.28.2
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-compilation-targets@7.29.7':
+    dependencies:
+      '@babel/compat-data': 7.29.7
+      '@babel/helper-validator-option': 7.29.7
       browserslist: 4.28.2
       lru-cache: 5.1.1
       semver: 6.3.1
@@ -4103,6 +4186,8 @@ snapshots:
 
   '@babel/helper-globals@7.28.0': {}
 
+  '@babel/helper-globals@7.29.7': {}
+
   '@babel/helper-member-expression-to-functions@7.28.5':
     dependencies:
       '@babel/traverse': 7.29.0
@@ -4117,6 +4202,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-module-imports@7.29.7':
+    dependencies:
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-module-transforms@7.28.6(@babel/core@7.23.7)':
     dependencies:
       '@babel/core': 7.23.7
@@ -4126,12 +4218,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)':
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.23.7)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-module-imports': 7.28.6
-      '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.29.0
+      '@babel/core': 7.23.7
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+      '@babel/traverse': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -4172,9 +4273,15 @@ snapshots:
 
   '@babel/helper-string-parser@7.27.1': {}
 
+  '@babel/helper-string-parser@7.29.7': {}
+
   '@babel/helper-validator-identifier@7.28.5': {}
 
+  '@babel/helper-validator-identifier@7.29.7': {}
+
   '@babel/helper-validator-option@7.27.1': {}
+
+  '@babel/helper-validator-option@7.29.7': {}
 
   '@babel/helper-wrap-function@7.28.6':
     dependencies:
@@ -4186,12 +4293,16 @@ snapshots:
 
   '@babel/helpers@7.26.10':
     dependencies:
-      '@babel/template': 7.28.6
-      '@babel/types': 7.29.0
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
 
   '@babel/parser@7.29.2':
     dependencies:
       '@babel/types': 7.29.0
+
+  '@babel/parser@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
 
   '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.27.1(@babel/core@7.23.7)':
     dependencies:
@@ -4797,6 +4908,12 @@ snapshots:
       '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
 
+  '@babel/template@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+
   '@babel/traverse@7.29.0':
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -4809,10 +4926,27 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/traverse@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-globals': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/types@7.29.0':
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@babel/types@7.29.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
 
   '@bcoe/v8-coverage@0.2.3': {}
 
@@ -5649,24 +5783,24 @@ snapshots:
 
   '@types/babel__core@7.20.5':
     dependencies:
-      '@babel/parser': 7.29.2
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
       '@types/babel__generator': 7.27.0
       '@types/babel__template': 7.4.4
       '@types/babel__traverse': 7.28.0
 
   '@types/babel__generator@7.27.0':
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
   '@types/babel__template@7.4.4':
     dependencies:
-      '@babel/parser': 7.29.2
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
 
   '@types/babel__traverse@7.28.0':
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
   '@types/body-parser@1.19.6':
     dependencies:
@@ -5897,19 +6031,19 @@ snapshots:
   '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4)(webpack@5.104.1)':
     dependencies:
       webpack: 5.104.1(webpack-cli@5.1.4)
-      webpack-cli: 5.1.4(webpack-dev-server@5.2.4)(webpack@5.104.1)
+      webpack-cli: 5.1.4(webpack-dev-server@5.2.5)(webpack@5.104.1)
 
   '@webpack-cli/info@2.0.2(webpack-cli@5.1.4)(webpack@5.104.1)':
     dependencies:
       webpack: 5.104.1(webpack-cli@5.1.4)
-      webpack-cli: 5.1.4(webpack-dev-server@5.2.4)(webpack@5.104.1)
+      webpack-cli: 5.1.4(webpack-dev-server@5.2.5)(webpack@5.104.1)
 
-  '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4)(webpack-dev-server@5.2.4)(webpack@5.104.1)':
+  '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4)(webpack-dev-server@5.2.5)(webpack@5.104.1)':
     dependencies:
       webpack: 5.104.1(webpack-cli@5.1.4)
-      webpack-cli: 5.1.4(webpack-dev-server@5.2.4)(webpack@5.104.1)
+      webpack-cli: 5.1.4(webpack-dev-server@5.2.5)(webpack@5.104.1)
     optionalDependencies:
-      webpack-dev-server: 5.2.4(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.104.1)
+      webpack-dev-server: 5.2.5(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.104.1)
 
   '@xtuc/ieee754@1.2.0': {}
 
@@ -6055,8 +6189,8 @@ snapshots:
 
   babel-plugin-jest-hoist@29.6.3:
     dependencies:
-      '@babel/template': 7.28.6
-      '@babel/types': 7.29.0
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
       '@types/babel__core': 7.20.5
       '@types/babel__traverse': 7.28.0
 
@@ -7006,7 +7140,7 @@ snapshots:
 
   http-parser-js@0.5.10: {}
 
-  http-proxy-middleware@2.0.9(@types/express@4.17.25):
+  http-proxy-middleware@2.0.10(@types/express@4.17.25):
     dependencies:
       '@types/http-proxy': 1.17.17
       http-proxy: 1.18.1
@@ -7158,7 +7292,7 @@ snapshots:
   istanbul-lib-instrument@5.2.1:
     dependencies:
       '@babel/core': 7.23.7
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.7
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
       semver: 6.3.1
@@ -7167,7 +7301,7 @@ snapshots:
 
   istanbul-lib-instrument@6.0.3:
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/parser': 7.29.2
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
@@ -8476,12 +8610,12 @@ snapshots:
     dependencies:
       minimalistic-assert: 1.0.1
 
-  webpack-cli@5.1.4(webpack-dev-server@5.2.4)(webpack@5.104.1):
+  webpack-cli@5.1.4(webpack-dev-server@5.2.5)(webpack@5.104.1):
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
       '@webpack-cli/configtest': 2.1.1(webpack-cli@5.1.4)(webpack@5.104.1)
       '@webpack-cli/info': 2.0.2(webpack-cli@5.1.4)(webpack@5.104.1)
-      '@webpack-cli/serve': 2.0.5(webpack-cli@5.1.4)(webpack-dev-server@5.2.4)(webpack@5.104.1)
+      '@webpack-cli/serve': 2.0.5(webpack-cli@5.1.4)(webpack-dev-server@5.2.5)(webpack@5.104.1)
       colorette: 2.0.20
       commander: 10.0.1
       cross-spawn: 7.0.5
@@ -8493,7 +8627,7 @@ snapshots:
       webpack: 5.104.1(webpack-cli@5.1.4)
       webpack-merge: 5.8.0
     optionalDependencies:
-      webpack-dev-server: 5.2.4(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.104.1)
+      webpack-dev-server: 5.2.5(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.104.1)
 
   webpack-dev-middleware@7.4.5(tslib@2.8.1)(webpack@5.104.1):
     dependencies:
@@ -8508,7 +8642,7 @@ snapshots:
     transitivePeerDependencies:
       - tslib
 
-  webpack-dev-server@5.2.4(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.104.1):
+  webpack-dev-server@5.2.5(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.104.1):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
@@ -8526,7 +8660,7 @@ snapshots:
       connect-history-api-fallback: 2.0.0
       express: 4.20.0
       graceful-fs: 4.2.11
-      http-proxy-middleware: 2.0.9(@types/express@4.17.25)
+      http-proxy-middleware: 2.0.10(@types/express@4.17.25)
       ipaddr.js: 2.3.0
       launch-editor: 2.14.1
       open: 10.2.0
@@ -8540,7 +8674,7 @@ snapshots:
       ws: 8.21.0
     optionalDependencies:
       webpack: 5.104.1(webpack-cli@5.1.4)
-      webpack-cli: 5.1.4(webpack-dev-server@5.2.4)(webpack@5.104.1)
+      webpack-cli: 5.1.4(webpack-dev-server@5.2.5)(webpack@5.104.1)
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -8585,7 +8719,7 @@ snapshots:
       watchpack: 2.5.1
       webpack-sources: 3.3.4
     optionalDependencies:
-      webpack-cli: 5.1.4(webpack-dev-server@5.2.4)(webpack@5.104.1)
+      webpack-cli: 5.1.4(webpack-dev-server@5.2.5)(webpack@5.104.1)
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild

--- a/src/tests/tron_wallet/ledger/ledger_sign_witness_fallback.test.ts
+++ b/src/tests/tron_wallet/ledger/ledger_sign_witness_fallback.test.ts
@@ -2,7 +2,7 @@ import { SignError } from '../../../base_wallet/error';
 import { LedgerTrxSigner } from '../../../tron_wallet';
 import { transaction } from '../constants';
 
-// 这些 mock 名字以 mock 开头,才能在被 hoist 的 jest.mock 工厂里引用
+// These mock names start with "mock" so they can be referenced inside the hoisted jest.mock factory
 const mockSignTransaction = jest.fn();
 const mockSignTransactionHash = jest.fn();
 
@@ -23,7 +23,7 @@ jest.mock('../../../tron_wallet/ledger/LedgerTrxWebHid', () => {
   };
 });
 
-// 模拟 Ledger app-tron 无法解析合约类型时设备返回的 APDU 错误
+// Simulates the APDU error the device returns when the Ledger app-tron cannot parse the contract type
 const error0x6a80 = new Error('Ledger device: UNKNOWN_ERROR (0x6a80)');
 
 const buildTx = (type: string) => {
@@ -40,7 +40,7 @@ describe('ledgerSign hash fallback for Ledger-unsupported contract types', () =>
     mockSignTransactionHash.mockReset();
   });
 
-  // 本次新增到 hashFallbackContracts 的超级代表相关合约类型
+  // Super Representative contract types newly added to hashFallbackContracts
   const witnessContracts = [
     'WitnessCreateContract',
     'WitnessUpdateContract',
@@ -48,7 +48,7 @@ describe('ledgerSign hash fallback for Ledger-unsupported contract types', () =>
   ];
 
   it.each(witnessContracts)(
-    '%s: 设备返回 0x6a80 时应回退到 signTransactionHash',
+    '%s: should fall back to signTransactionHash when the device returns 0x6a80',
     async (contractType) => {
       mockSignTransaction.mockRejectedValue(error0x6a80);
       mockSignTransactionHash.mockResolvedValue('hash signature');
@@ -56,26 +56,26 @@ describe('ledgerSign hash fallback for Ledger-unsupported contract types', () =>
       const tx = buildTx(contractType);
       const result = await ledgerTrxSigner.ledgerSign({ data: tx, path: 'm/44/195/0' });
 
-      // 回退路径被走到,且用交易 hash 调用
+      // The fallback path is taken and called with the transaction hash
       expect(mockSignTransactionHash).toHaveBeenCalledTimes(1);
       expect(mockSignTransactionHash).toHaveBeenCalledWith('m/44/195/0', tx.txID);
-      // 签名结果来自 hash 签名
+      // The signature result comes from hash signing
       expect(result.signature).toEqual(['hash signature']);
     },
   );
 
-  it('未列入 hashFallbackContracts 的类型遇到 0x6a80 仍抛 SignError(不回退)', async () => {
+  it('a type not in hashFallbackContracts still throws SignError on 0x6a80 (no fallback)', async () => {
     mockSignTransaction.mockRejectedValue(error0x6a80);
     mockSignTransactionHash.mockResolvedValue('hash signature');
 
     const tx = buildTx('AccountCreateContract');
 
     await expect(ledgerTrxSigner.ledgerSign({ data: tx, path: '' })).rejects.toThrow(SignError);
-    // 不应触发 hash 回退签名
+    // Hash fallback signing should not be triggered
     expect(mockSignTransactionHash).not.toHaveBeenCalled();
   });
 
-  it('超级代表交易若设备直接签名成功,则不会触发 hash 回退', async () => {
+  it('a Super Representative transaction signed directly by the device does not trigger hash fallback', async () => {
     mockSignTransaction.mockResolvedValue('device signature');
 
     const tx = buildTx('WitnessCreateContract');

--- a/src/tests/tron_wallet/ledger/ledger_sign_witness_fallback.test.ts
+++ b/src/tests/tron_wallet/ledger/ledger_sign_witness_fallback.test.ts
@@ -1,0 +1,87 @@
+import { SignError } from '../../../base_wallet/error';
+import { LedgerTrxSigner } from '../../../tron_wallet';
+import { transaction } from '../constants';
+
+// 这些 mock 名字以 mock 开头,才能在被 hoist 的 jest.mock 工厂里引用
+const mockSignTransaction = jest.fn();
+const mockSignTransactionHash = jest.fn();
+
+jest.mock('../../../tron_wallet/ledger/LedgerTrxWebHid', () => {
+  const originalModule = jest.requireActual('../../../tron_wallet/ledger/LedgerTrxWebHid');
+  return {
+    __esModule: true,
+    ...originalModule,
+    LedgerTrxWebHid: class MockLedgerTrxWebHid {
+      signTransaction() {
+        return mockSignTransaction();
+      }
+
+      signTransactionHash(...args: any[]) {
+        return mockSignTransactionHash(...args);
+      }
+    },
+  };
+});
+
+// 模拟 Ledger app-tron 无法解析合约类型时设备返回的 APDU 错误
+const error0x6a80 = new Error('Ledger device: UNKNOWN_ERROR (0x6a80)');
+
+const buildTx = (type: string) => {
+  const tx = JSON.parse(JSON.stringify(transaction));
+  tx.raw_data.contract[0].type = type;
+  return tx;
+};
+
+describe('ledgerSign hash fallback for Ledger-unsupported contract types', () => {
+  const ledgerTrxSigner = new LedgerTrxSigner();
+
+  beforeEach(() => {
+    mockSignTransaction.mockReset();
+    mockSignTransactionHash.mockReset();
+  });
+
+  // 本次新增到 hashFallbackContracts 的超级代表相关合约类型
+  const witnessContracts = [
+    'WitnessCreateContract',
+    'WitnessUpdateContract',
+    'UpdateBrokerageContract',
+  ];
+
+  it.each(witnessContracts)(
+    '%s: 设备返回 0x6a80 时应回退到 signTransactionHash',
+    async (contractType) => {
+      mockSignTransaction.mockRejectedValue(error0x6a80);
+      mockSignTransactionHash.mockResolvedValue('hash signature');
+
+      const tx = buildTx(contractType);
+      const result = await ledgerTrxSigner.ledgerSign({ data: tx, path: 'm/44/195/0' });
+
+      // 回退路径被走到,且用交易 hash 调用
+      expect(mockSignTransactionHash).toHaveBeenCalledTimes(1);
+      expect(mockSignTransactionHash).toHaveBeenCalledWith('m/44/195/0', tx.txID);
+      // 签名结果来自 hash 签名
+      expect(result.signature).toEqual(['hash signature']);
+    },
+  );
+
+  it('未列入 hashFallbackContracts 的类型遇到 0x6a80 仍抛 SignError(不回退)', async () => {
+    mockSignTransaction.mockRejectedValue(error0x6a80);
+    mockSignTransactionHash.mockResolvedValue('hash signature');
+
+    const tx = buildTx('AccountCreateContract');
+
+    await expect(ledgerTrxSigner.ledgerSign({ data: tx, path: '' })).rejects.toThrow(SignError);
+    // 不应触发 hash 回退签名
+    expect(mockSignTransactionHash).not.toHaveBeenCalled();
+  });
+
+  it('超级代表交易若设备直接签名成功,则不会触发 hash 回退', async () => {
+    mockSignTransaction.mockResolvedValue('device signature');
+
+    const tx = buildTx('WitnessCreateContract');
+    const result = await ledgerTrxSigner.ledgerSign({ data: tx, path: '' });
+
+    expect(mockSignTransactionHash).not.toHaveBeenCalled();
+    expect(result.signature).toEqual(['device signature']);
+  });
+});

--- a/src/tests/userStatistics/assetPrecipitation.test.ts
+++ b/src/tests/userStatistics/assetPrecipitation.test.ts
@@ -1,0 +1,66 @@
+import { updateAddressAssetPrecipitation } from '../../userStatistics/assetPrecipitation';
+import { ExternalDependencies } from '../../userStatistics/ExternalDeps';
+import { AddressAssetPrecipitation } from '../../userStatistics/types';
+
+function createDeps(
+  existing: AddressAssetPrecipitation | null,
+): { deps: ExternalDependencies; saved: AddressAssetPrecipitation[] } {
+  const saved: AddressAssetPrecipitation[] = [];
+  const deps = {
+    saveAssetPrecipitation: async (data: AddressAssetPrecipitation) => {
+      saved.push(data);
+    },
+    loadAssetPrecipitation: async () => existing,
+  } as unknown as ExternalDependencies;
+  return { deps, saved };
+}
+
+const rawData: AddressAssetPrecipitation = {
+  uid: 'uid1',
+  addressType: 1,
+  trxBalance: '100.123456',
+  usdtBalance: '50.999',
+  totalBalanceInUSD: '150.55',
+  realTokenUsd: '9.87',
+  date: '2026-07-06',
+};
+
+describe('updateAddressAssetPrecipitation', () => {
+  it('formats trxBalance, usdtBalance, totalBalanceInUSD and realTokenUsd before saving', async () => {
+    const { deps, saved } = createDeps(null);
+
+    const result = await updateAddressAssetPrecipitation('addr', rawData, deps);
+
+    expect(saved).toHaveLength(1);
+    expect(saved[0]).toMatchObject({
+      trxBalance: '100',
+      usdtBalance: '50.9',
+      totalBalanceInUSD: '150',
+      realTokenUsd: '9.8',
+      isNeedReport: true,
+    });
+    // the returned value is the formatted data as well
+    expect(result.trxBalance).toBe('100');
+    expect(result.usdtBalance).toBe('50.9');
+    expect(result.totalBalanceInUSD).toBe('150');
+    expect(result.realTokenUsd).toBe('9.8');
+  });
+
+  it('compares against existing data using the formatted values', async () => {
+    // existing already holds the formatted balances -> nothing new to save
+    const existing: AddressAssetPrecipitation = {
+      ...rawData,
+      id: 7,
+      trxBalance: '100',
+      usdtBalance: '50.9',
+      totalBalanceInUSD: '150',
+      realTokenUsd: '9.8',
+    };
+    const { deps, saved } = createDeps(existing);
+
+    const result = await updateAddressAssetPrecipitation('addr', rawData, deps);
+
+    expect(saved).toHaveLength(0);
+    expect(result).toBe(existing);
+  });
+});

--- a/src/tests/userStatistics/report.test.ts
+++ b/src/tests/userStatistics/report.test.ts
@@ -1,0 +1,106 @@
+import { buildFundReportString, truncateDecimals } from '../../userStatistics/report';
+import { AddressAssetPrecipitation } from '../../userStatistics/types';
+
+describe('truncateDecimals', () => {
+  it('truncates the fractional part without rounding', () => {
+    expect(truncateDecimals('123.99')).toBe('123');
+    expect(truncateDecimals('0.9')).toBe('0');
+    expect(truncateDecimals('9.5')).toBe('9');
+  });
+
+  it('keeps integer strings unchanged', () => {
+    expect(truncateDecimals('123')).toBe('123');
+    expect(truncateDecimals('0')).toBe('0');
+  });
+
+  it('strips leading zeros', () => {
+    expect(truncateDecimals('007')).toBe('7');
+    expect(truncateDecimals('00')).toBe('0');
+    expect(truncateDecimals('000.5')).toBe('0');
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(truncateDecimals('  42.7  ')).toBe('42');
+  });
+
+  it('handles negative values and avoids "-0"', () => {
+    expect(truncateDecimals('-123.99')).toBe('-123');
+    expect(truncateDecimals('-0.5')).toBe('0');
+    expect(truncateDecimals('-0')).toBe('0');
+  });
+
+  it('does not lose precision for large integers (beyond 2^53)', () => {
+    expect(truncateDecimals('9999999999999999')).toBe('9999999999999999');
+    expect(truncateDecimals('123456789012345678901234.56')).toBe(
+      '123456789012345678901234',
+    );
+  });
+
+  it('never emits scientific notation for very large numbers', () => {
+    const result = truncateDecimals('1000000000000000000000');
+    expect(result).toBe('1000000000000000000000');
+    expect(result).not.toContain('e');
+  });
+
+  it('falls back to "0" for non-numeric or malformed input', () => {
+    expect(truncateDecimals('')).toBe('0');
+    expect(truncateDecimals('abc')).toBe('0');
+    expect(truncateDecimals('NaN')).toBe('0');
+    expect(truncateDecimals('1e21')).toBe('0');
+    expect(truncateDecimals('12.')).toBe('0');
+    expect(truncateDecimals('.5')).toBe('0');
+    expect(truncateDecimals('1,000')).toBe('0');
+    expect(truncateDecimals('12 34')).toBe('0');
+  });
+
+  it('falls back to "0" for non-string input', () => {
+    expect(truncateDecimals(undefined as unknown as string)).toBe('0');
+    expect(truncateDecimals(null as unknown as string)).toBe('0');
+    expect(truncateDecimals(123 as unknown as string)).toBe('0');
+  });
+});
+
+describe('buildFundReportString', () => {
+  const baseRecord: AddressAssetPrecipitation = {
+    uid: 'uid1',
+    addressType: 1,
+    trxBalance: '100.123456',
+    usdtBalance: '50.999',
+    totalBalanceInUSD: '150.5',
+    realTokenUsd: '9.87',
+    date: '2026-07-06',
+  };
+
+  it('truncates trxBalance, usdtBalance and realTokenUsd in the output string', () => {
+    expect(buildFundReportString([baseRecord])).toBe(
+      'V1X|uid1|1|100|50|9|2026-07-06|',
+    );
+  });
+
+  it('applies the "0" fallback to malformed numeric fields', () => {
+    const record: AddressAssetPrecipitation = {
+      ...baseRecord,
+      trxBalance: '',
+      usdtBalance: 'abc',
+      realTokenUsd: '1e21',
+    };
+    expect(buildFundReportString([record])).toBe('V1X|uid1|1|0|0|0|2026-07-06|');
+  });
+
+  it('concatenates multiple records', () => {
+    const second: AddressAssetPrecipitation = {
+      ...baseRecord,
+      uid: 'uid2',
+      trxBalance: '7.7',
+      usdtBalance: '8.8',
+      realTokenUsd: '9.9',
+    };
+    expect(buildFundReportString([baseRecord, second])).toBe(
+      'V1X|uid1|1|100|50|9|2026-07-06|V1X|uid2|1|7|8|9|2026-07-06|',
+    );
+  });
+
+  it('returns an empty string for no records', () => {
+    expect(buildFundReportString([])).toBe('');
+  });
+});

--- a/src/tests/userStatistics/report.test.ts
+++ b/src/tests/userStatistics/report.test.ts
@@ -1,64 +1,5 @@
-import { buildFundReportString, truncateDecimals } from '../../userStatistics/report';
+import { buildFundReportString } from '../../userStatistics/report';
 import { AddressAssetPrecipitation } from '../../userStatistics/types';
-
-describe('truncateDecimals', () => {
-  it('truncates the fractional part without rounding', () => {
-    expect(truncateDecimals('123.99')).toBe('123');
-    expect(truncateDecimals('0.9')).toBe('0');
-    expect(truncateDecimals('9.5')).toBe('9');
-  });
-
-  it('keeps integer strings unchanged', () => {
-    expect(truncateDecimals('123')).toBe('123');
-    expect(truncateDecimals('0')).toBe('0');
-  });
-
-  it('strips leading zeros', () => {
-    expect(truncateDecimals('007')).toBe('7');
-    expect(truncateDecimals('00')).toBe('0');
-    expect(truncateDecimals('000.5')).toBe('0');
-  });
-
-  it('trims surrounding whitespace', () => {
-    expect(truncateDecimals('  42.7  ')).toBe('42');
-  });
-
-  it('handles negative values and avoids "-0"', () => {
-    expect(truncateDecimals('-123.99')).toBe('-123');
-    expect(truncateDecimals('-0.5')).toBe('0');
-    expect(truncateDecimals('-0')).toBe('0');
-  });
-
-  it('does not lose precision for large integers (beyond 2^53)', () => {
-    expect(truncateDecimals('9999999999999999')).toBe('9999999999999999');
-    expect(truncateDecimals('123456789012345678901234.56')).toBe(
-      '123456789012345678901234',
-    );
-  });
-
-  it('never emits scientific notation for very large numbers', () => {
-    const result = truncateDecimals('1000000000000000000000');
-    expect(result).toBe('1000000000000000000000');
-    expect(result).not.toContain('e');
-  });
-
-  it('falls back to "0" for non-numeric or malformed input', () => {
-    expect(truncateDecimals('')).toBe('0');
-    expect(truncateDecimals('abc')).toBe('0');
-    expect(truncateDecimals('NaN')).toBe('0');
-    expect(truncateDecimals('1e21')).toBe('0');
-    expect(truncateDecimals('12.')).toBe('0');
-    expect(truncateDecimals('.5')).toBe('0');
-    expect(truncateDecimals('1,000')).toBe('0');
-    expect(truncateDecimals('12 34')).toBe('0');
-  });
-
-  it('falls back to "0" for non-string input', () => {
-    expect(truncateDecimals(undefined as unknown as string)).toBe('0');
-    expect(truncateDecimals(null as unknown as string)).toBe('0');
-    expect(truncateDecimals(123 as unknown as string)).toBe('0');
-  });
-});
 
 describe('buildFundReportString', () => {
   const baseRecord: AddressAssetPrecipitation = {
@@ -71,9 +12,9 @@ describe('buildFundReportString', () => {
     date: '2026-07-06',
   };
 
-  it('truncates trxBalance, usdtBalance and realTokenUsd in the output string', () => {
+  it('formats trxBalance, usdtBalance and realTokenUsd in the output string', () => {
     expect(buildFundReportString([baseRecord])).toBe(
-      'V1X|uid1|1|100|50|9|2026-07-06|',
+      'V1X|uid1|1|100|50.9|9.8|2026-07-06|',
     );
   });
 
@@ -82,7 +23,7 @@ describe('buildFundReportString', () => {
       ...baseRecord,
       trxBalance: '',
       usdtBalance: 'abc',
-      realTokenUsd: '1e21',
+      realTokenUsd: 'NaN',
     };
     expect(buildFundReportString([record])).toBe('V1X|uid1|1|0|0|0|2026-07-06|');
   });
@@ -96,7 +37,7 @@ describe('buildFundReportString', () => {
       realTokenUsd: '9.9',
     };
     expect(buildFundReportString([baseRecord, second])).toBe(
-      'V1X|uid1|1|100|50|9|2026-07-06|V1X|uid2|1|7|8|9|2026-07-06|',
+      'V1X|uid1|1|100|50.9|9.8|2026-07-06|V1X|uid2|1|7.7|8.8|9.9|2026-07-06|',
     );
   });
 

--- a/src/tests/userStatistics/txnReport.test.ts
+++ b/src/tests/userStatistics/txnReport.test.ts
@@ -1,0 +1,59 @@
+import { buildTxnReportString } from '../../userStatistics/report';
+import { TransactionRecord } from '../../userStatistics/types';
+
+const baseRecord: TransactionRecord = {
+  uid: 'uid1',
+  addressType: 1,
+  contractType: 3,
+  actionType: 1053,
+  count: 3,
+  tokenAddress: 'token-addr-1',
+  energy: '65000',
+  bandwidth: '345',
+  burn: '0',
+  date: '2026-07-07',
+  txnAmountDistributions: [{ range: '100_1k', count: 3 }],
+};
+
+describe('buildTxnReportString', () => {
+  it('writes a literal 0 in the 7th (former tokenAmount) segment', () => {
+    expect(buildTxnReportString([baseRecord])).toBe(
+      'V1Y|uid1|1|1053|3|token-addr-1|0|65000|345|0|2026-07-07|A4:3|',
+    );
+  });
+
+  it('keeps the V1Y layout at 12 pipe-delimited segments (trailing empty)', () => {
+    const out = buildTxnReportString([baseRecord]);
+    // trailing '|' yields an empty final element; the record occupies 12 segments
+    const segments = out.split('|');
+    expect(segments).toHaveLength(13);
+    expect(segments[12]).toBe('');
+    // 7th segment (index 6) is the placeholder
+    expect(segments[6]).toBe('0');
+  });
+
+  it('maps distribution ranges and joins them', () => {
+    const record: TransactionRecord = {
+      ...baseRecord,
+      txnAmountDistributions: [
+        { range: '0_1', count: 2 },
+        { range: '10m_infinite', count: 1 },
+      ],
+    };
+    expect(buildTxnReportString([record])).toBe(
+      'V1Y|uid1|1|1053|3|token-addr-1|0|65000|345|0|2026-07-07|A1:2,A9:1|',
+    );
+  });
+
+  it('concatenates multiple records', () => {
+    const second: TransactionRecord = { ...baseRecord, uid: 'uid2', count: 1 };
+    expect(buildTxnReportString([baseRecord, second])).toBe(
+      'V1Y|uid1|1|1053|3|token-addr-1|0|65000|345|0|2026-07-07|A4:3|' +
+        'V1Y|uid2|1|1053|1|token-addr-1|0|65000|345|0|2026-07-07|A4:3|',
+    );
+  });
+
+  it('returns an empty string for no records', () => {
+    expect(buildTxnReportString([])).toBe('');
+  });
+});

--- a/src/tests/userStatistics/utils.test.ts
+++ b/src/tests/userStatistics/utils.test.ts
@@ -1,0 +1,90 @@
+import { formatReportNumber } from '../../userStatistics/utils';
+
+describe('formatReportNumber', () => {
+  it('keeps at most 3 significant digits, truncating (not rounding)', () => {
+    expect(formatReportNumber('123.456')).toBe('123');
+    expect(formatReportNumber('123.6')).toBe('123');
+    expect(formatReportNumber('12345.6')).toBe('12300');
+    expect(formatReportNumber('999.9')).toBe('999');
+  });
+
+  it('keeps at most 1 decimal place, truncating (more restrictive than 3 sig digits)', () => {
+    expect(formatReportNumber('1.26')).toBe('1.2');
+    expect(formatReportNumber('1.456')).toBe('1.4');
+    expect(formatReportNumber('12.36')).toBe('12.3');
+    expect(formatReportNumber('0.126')).toBe('0.1');
+    expect(formatReportNumber('0.05')).toBe('0');
+  });
+
+  it('leaves values already within both limits unchanged', () => {
+    expect(formatReportNumber('9.5')).toBe('9.5');
+    expect(formatReportNumber('0.9')).toBe('0.9');
+    expect(formatReportNumber('7.7')).toBe('7.7');
+    expect(formatReportNumber('0')).toBe('0');
+    expect(formatReportNumber('123')).toBe('123');
+  });
+
+  it('truncates sub-1 values toward zero', () => {
+    expect(formatReportNumber('0.999')).toBe('0.9');
+    expect(formatReportNumber('-0.99')).toBe('-0.9');
+  });
+
+  it('collapses any value below 0.1 to "0" (1-decimal-place limit)', () => {
+    expect(formatReportNumber('0.09')).toBe('0');
+    expect(formatReportNumber('0.001234')).toBe('0');
+    expect(formatReportNumber('0.0001')).toBe('0');
+    expect(formatReportNumber('1e-3')).toBe('0');
+    expect(formatReportNumber('-0.05')).toBe('0');
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(formatReportNumber('  42.5  ')).toBe('42.5');
+  });
+
+  it('falls back to "0" for infinite values', () => {
+    expect(formatReportNumber('Infinity')).toBe('0');
+    expect(formatReportNumber('-Infinity')).toBe('0');
+  });
+
+  it('handles negatives (truncating toward zero) and avoids "-0"', () => {
+    expect(formatReportNumber('-123.99')).toBe('-123');
+    expect(formatReportNumber('-0.5')).toBe('-0.5');
+    expect(formatReportNumber('-0.04')).toBe('0');
+  });
+
+  it('never emits scientific notation for very large numbers', () => {
+    const result = formatReportNumber('123456789012345678901234.56');
+    expect(result).toBe('123000000000000000000000');
+    expect(result).not.toContain('e');
+  });
+
+  it('accepts scientific-notation input and expands it', () => {
+    expect(formatReportNumber('1e21')).toBe('1000000000000000000000');
+  });
+
+  it('falls back to "0" for non-numeric input', () => {
+    expect(formatReportNumber('')).toBe('0');
+    expect(formatReportNumber('abc')).toBe('0');
+    expect(formatReportNumber('NaN')).toBe('0');
+    expect(formatReportNumber('1,000')).toBe('0');
+  });
+
+  it('accepts number input (runtime type from @ts-ignore callers)', () => {
+    expect(formatReportNumber(123)).toBe('123');
+    expect(formatReportNumber(50.999)).toBe('50.9');
+    expect(formatReportNumber(0)).toBe('0');
+    expect(formatReportNumber(-0.99)).toBe('-0.9');
+  });
+
+  it('falls back to "0" for non-numeric number input', () => {
+    expect(formatReportNumber(NaN)).toBe('0');
+    expect(formatReportNumber(Infinity)).toBe('0');
+    expect(formatReportNumber(-Infinity)).toBe('0');
+  });
+
+  it('falls back to "0" for null/undefined/other non-string, non-number input', () => {
+    expect(formatReportNumber(undefined as unknown as string)).toBe('0');
+    expect(formatReportNumber(null as unknown as string)).toBe('0');
+    expect(formatReportNumber({} as unknown as string)).toBe('0');
+  });
+});

--- a/src/tron_wallet/ledger/LedgerTrxSigner.ts
+++ b/src/tron_wallet/ledger/LedgerTrxSigner.ts
@@ -166,18 +166,24 @@ export class LedgerTrxSigner extends LedgerSigner {
       }
       return transaction;
     } catch (error: any) {
-      const stakeV2Contracts = [
+      // Ledger app-tron 无法解析的合约类型,设备返回 0x6a80,需回退到 hash 签名
+      const hashFallbackContracts = [
+        // 质押 2.0 相关
         'FreezeBalanceV2Contract',
         'UnfreezeBalanceV2Contract',
         'WithdrawExpireUnfreezeContract',
         'DelegateResourceContract',
         'UnDelegateResourceContract',
         'CancelAllUnfreezeV2Contract',
+        // 超级代表相关
+        'WitnessCreateContract',
+        'WitnessUpdateContract',
+        'UpdateBrokerageContract',
       ];
 
       if (/Too many bytes to encode/.test(error.message)) {
         return await signHash(ledgerWebHid, transaction, path);
-      } else if (error.toString().includes('0x6a80') && stakeV2Contracts.includes(contractType)) {
+      } else if (error.toString().includes('0x6a80') && hashFallbackContracts.includes(contractType)) {
         return await signHash(ledgerWebHid, transaction, path);
       } else {
         throw new SignError(error.message);

--- a/src/tron_wallet/ledger/LedgerTrxSigner.ts
+++ b/src/tron_wallet/ledger/LedgerTrxSigner.ts
@@ -166,16 +166,16 @@ export class LedgerTrxSigner extends LedgerSigner {
       }
       return transaction;
     } catch (error: any) {
-      // Ledger app-tron 无法解析的合约类型,设备返回 0x6a80,需回退到 hash 签名
+      // Contract types the Ledger app-tron cannot parse: the device returns 0x6a80, so fall back to hash signing
       const hashFallbackContracts = [
-        // 质押 2.0 相关
+        // Stake 2.0 related
         'FreezeBalanceV2Contract',
         'UnfreezeBalanceV2Contract',
         'WithdrawExpireUnfreezeContract',
         'DelegateResourceContract',
         'UnDelegateResourceContract',
         'CancelAllUnfreezeV2Contract',
-        // 超级代表相关
+        // Super Representative related
         'WitnessCreateContract',
         'WitnessUpdateContract',
         'UpdateBrokerageContract',

--- a/src/userStatistics/assetPrecipitation.ts
+++ b/src/userStatistics/assetPrecipitation.ts
@@ -1,6 +1,6 @@
 import { ExternalDependencies } from './ExternalDeps';
 import { AddressAssetPrecipitation } from './types';
-import { getCurrentUtcDate } from './utils';
+import { formatReportNumber, getCurrentUtcDate } from './utils';
 
 async function saveAddressAssetPrecipitation(
   address: string,
@@ -20,9 +20,16 @@ async function loadAssetPrecipitationBy(
 
 export async function updateAddressAssetPrecipitation(
   address: string,
-  newData: AddressAssetPrecipitation,
+  rawData: AddressAssetPrecipitation,
   deps: ExternalDependencies
 ): Promise<AddressAssetPrecipitation> {
+  const newData: AddressAssetPrecipitation = {
+    ...rawData,
+    trxBalance: formatReportNumber(rawData.trxBalance),
+    usdtBalance: formatReportNumber(rawData.usdtBalance),
+    totalBalanceInUSD: formatReportNumber(rawData.totalBalanceInUSD),
+    realTokenUsd: formatReportNumber(rawData.realTokenUsd),
+  };
   const date = getCurrentUtcDate();
   const existingData = await loadAssetPrecipitationBy(address, date, deps);
 

--- a/src/userStatistics/report.ts
+++ b/src/userStatistics/report.ts
@@ -8,26 +8,14 @@ import {
   updateAndDeleteAllReportedTransactionRecord,
 } from './transactionRecord';
 import { AddressAssetPrecipitation, TransactionRecord } from './types';
-
-export function truncateDecimals(value: string): string {
-  if (typeof value !== 'string') {
-    return '0';
-  }
-  const s = value.trim();
-  const m = /^(-?)(\d+)(\.\d+)?$/.exec(s);
-  if (!m) {
-    return '0';
-  }
-  const intPart = m[2].replace(/^0+(?=\d)/, '');
-  return (m[1] && intPart !== '0' ? '-' : '') + intPart;
-}
+import { formatReportNumber } from './utils';
 
 export function buildFundReportString(records: AddressAssetPrecipitation[]): string {
   return records
     .map((record) => {
-      const trxBalance = truncateDecimals(record.trxBalance);
-      const usdtBalance = truncateDecimals(record.usdtBalance);
-      const realTokenUsd = truncateDecimals(record.realTokenUsd);
+      const trxBalance = formatReportNumber(record.trxBalance);
+      const usdtBalance = formatReportNumber(record.usdtBalance);
+      const realTokenUsd = formatReportNumber(record.realTokenUsd);
       return `V1X|${record.uid}|${record.addressType}|${trxBalance}|${usdtBalance}|${realTokenUsd}|${record.date}|`;
     })
     .join('');

--- a/src/userStatistics/report.ts
+++ b/src/userStatistics/report.ts
@@ -9,12 +9,27 @@ import {
 } from './transactionRecord';
 import { AddressAssetPrecipitation, TransactionRecord } from './types';
 
-function buildFundReportString(records: AddressAssetPrecipitation[]): string {
+export function truncateDecimals(value: string): string {
+  if (typeof value !== 'string') {
+    return '0';
+  }
+  const s = value.trim();
+  const m = /^(-?)(\d+)(\.\d+)?$/.exec(s);
+  if (!m) {
+    return '0';
+  }
+  const intPart = m[2].replace(/^0+(?=\d)/, '');
+  return (m[1] && intPart !== '0' ? '-' : '') + intPart;
+}
+
+export function buildFundReportString(records: AddressAssetPrecipitation[]): string {
   return records
-    .map(
-      (record) =>
-        `V1X|${record.uid}|${record.addressType}|${record.trxBalance}|${record.usdtBalance}|${record.realTokenUsd}|${record.date}|`,
-    )
+    .map((record) => {
+      const trxBalance = truncateDecimals(record.trxBalance);
+      const usdtBalance = truncateDecimals(record.usdtBalance);
+      const realTokenUsd = truncateDecimals(record.realTokenUsd);
+      return `V1X|${record.uid}|${record.addressType}|${trxBalance}|${usdtBalance}|${realTokenUsd}|${record.date}|`;
+    })
     .join('');
 }
 

--- a/src/userStatistics/report.ts
+++ b/src/userStatistics/report.ts
@@ -33,7 +33,7 @@ const rangeMap: Record<string, string> = {
   '10m_infinite': 'A9',
 };
 
-function buildTxnReportString(records: TransactionRecord[]): string {
+export function buildTxnReportString(records: TransactionRecord[]): string {
   return records
     .map((record) => {
       const distStr = (record.txnAmountDistributions || [])
@@ -43,7 +43,7 @@ function buildTxnReportString(records: TransactionRecord[]): string {
         })
         .join(',');
 
-      return `V1Y|${record.uid}|${record.addressType}|${record.actionType}|${record.count}|${record.tokenAddress}|${record.tokenAmount}|${record.energy}|${record.bandwidth}|${record.burn}|${record.date}|${distStr}|`;
+      return `V1Y|${record.uid}|${record.addressType}|${record.actionType}|${record.count}|${record.tokenAddress}|0|${record.energy}|${record.bandwidth}|${record.burn}|${record.date}|${distStr}|`;
     })
     .join('');
 }

--- a/src/userStatistics/transactionRecord.ts
+++ b/src/userStatistics/transactionRecord.ts
@@ -51,7 +51,6 @@ export async function updateTransactionRecord(
   );
 
   if (existing) {
-    existing.tokenAmount = safeAdd(existing.tokenAmount, newRecord.tokenAmount);
     existing.count = Number(safeAdd(existing.count, newRecord.count));
     existing.energy = safeAdd(existing.energy, newRecord.energy);
     existing.bandwidth = safeAdd(existing.bandwidth, newRecord.bandwidth);

--- a/src/userStatistics/types.ts
+++ b/src/userStatistics/types.ts
@@ -83,7 +83,6 @@ export type TransactionRecord = {
   actionType: number;
   count: number;
   tokenAddress: string;
-  tokenAmount: string;
   energy: string;
   bandwidth: string;
   burn: string;

--- a/src/userStatistics/userStatistics.ts
+++ b/src/userStatistics/userStatistics.ts
@@ -141,7 +141,6 @@ export async function getAndUpdateTransactionRecord(
         actionType,
         count: 1,
         tokenAddress,
-        tokenAmount: amountFormat,
         energy: transferCostInfo.energy.toString(),
         bandwidth: transferCostInfo.bandwidth.toString(),
         burn: transferCostInfo.burn.toString(),

--- a/src/userStatistics/utils.ts
+++ b/src/userStatistics/utils.ts
@@ -1,3 +1,5 @@
+import { BigNumber } from 'bignumber.js';
+
 // month starts from 0, so we need to add 1
 export function getCurrentUtcDate(): string {
   const now = new Date();
@@ -5,4 +7,21 @@ export function getCurrentUtcDate(): string {
   const month = String(now.getUTCMonth() + 1).padStart(2, '0');
   const day = String(now.getUTCDate()).padStart(2, '0');
   return `${year}-${month}-${day}`;
+}
+
+// Keep at most 3 significant digits and at most 1 decimal place.
+// Accepts number too: some callers (e.g. realTokenUsd from the @ts-ignore
+// backendManager chain) may pass a runtime number despite the string type.
+export function formatReportNumber(value: string | number): string {
+  if (typeof value !== 'string' && typeof value !== 'number') {
+    return '0';
+  }
+  const bn = new BigNumber(value);
+  if (!bn.isFinite()) {
+    return '0';
+  }
+  return bn
+    .precision(3, BigNumber.ROUND_DOWN)
+    .decimalPlaces(1, BigNumber.ROUND_DOWN)
+    .toFixed();
 }


### PR DESCRIPTION
Overview

This release includes a Ledger signing fix for Super Representative transactions, privacy and precision improvements to user statistics reporting, and dependency security upgrades. Version 1.1.0 → 1.1.1.

Changes

🐛 Ledger: fall back to hash signing for Super Representative transactions

- The Ledger app-tron cannot parse SR-related contract types and the device returns 0x6a80. Added WitnessCreateContract, WitnessUpdateContract, and UpdateBrokerageContract to the hash-signing fallback list (same mechanism as Stake 2.0 contracts), and renamed stakeV2Contracts to hashFallbackContracts (src/tron_wallet/ledger/LedgerTrxSigner.ts)
- Added unit tests for the fallback logic in ledger_sign_witness_fallback.test.ts

🔒 userStatistics: remove tokenAmount and reduce reported precision

- Removed transaction amount field: TransactionRecord no longer stores or accumulates tokenAmount; the field is hardcoded to 0 in the V1Y report string (only the transaction count, resource costs, and the 9-bucket amount distribution histogram remain)
- Reduced asset balance precision: added a formatReportNumber utility (at most 3 significant digits and 1 decimal place, rounded down), applied to:
  - Normalizing trxBalance / usdtBalance / totalBalanceInUSD / realTokenUsd before persisting asset precipitation data
  - Balance fields when building the V1X fund report string
- Updated the V1Y payload spec in PRIVACY.md to match the implementation
- Added tests: assetPrecipitation.test.ts, report.test.ts, txnReport.test.ts, utils.test.ts

🔧 Chores

- Bumped webpack-dev-server 5.2.4 → 5.2.5 and http-proxy-middleware 2.0.9 → 2.0.10 to fix audit warnings
- Translated Chinese comments and test names in the Ledger module to English