### PR TITLE
fix(deps): pin websocket-driver 0.7.5 to resolve GHSA-xv26-6w52-cph6

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,8 @@
       "@babel/plugin-transform-modules-systemjs": "7.29.4",
       "uuid": "11.1.1",
       "js-yaml": "4.2.0",
-      "launch-editor": "2.14.1"
+      "launch-editor": "2.14.1",
+      "websocket-driver": "0.7.5"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,6 +40,7 @@ overrides:
   uuid: 11.1.1
   js-yaml: 4.2.0
   launch-editor: 2.14.1
+  websocket-driver: 0.7.5
 
 importers:
 
@@ -3945,8 +3946,8 @@ packages:
       webpack-cli:
         optional: true
 
-  websocket-driver@0.7.4:
-    resolution: {integrity: sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==}
+  websocket-driver@0.7.5:
+    resolution: {integrity: sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==}
     engines: {node: '>=0.8.0'}
 
   websocket-extensions@0.1.4:
@@ -6911,7 +6912,7 @@ snapshots:
 
   faye-websocket@0.11.4:
     dependencies:
-      websocket-driver: 0.7.4
+      websocket-driver: 0.7.5
 
   fb-watchman@2.0.2:
     dependencies:
@@ -8318,7 +8319,7 @@ snapshots:
     dependencies:
       faye-websocket: 0.11.4
       uuid: 11.1.1
-      websocket-driver: 0.7.4
+      websocket-driver: 0.7.5
 
   source-map-support@0.5.13:
     dependencies:
@@ -8725,7 +8726,7 @@ snapshots:
       - esbuild
       - uglify-js
 
-  websocket-driver@0.7.4:
+  websocket-driver@0.7.5:
     dependencies:
       http-parser-js: 0.5.10
       safe-buffer: 5.2.1


### PR DESCRIPTION
Add pnpm override for websocket-driver (dev-only transitive dep via webpack-dev-server > sockjs) to clear the critical CVE-2026-54466 audit finding. Lockfile refresh also aligns webpack-dev-server to the already-declared 5.2.5.