### PR TITLE
fix(deps): bump fast-uri override to 3.1.4 to resolve GHSA-v2hh-gcrm-…

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
       "serialize-javascript": "7.0.5",
       "picomatch": "2.3.2",
       "follow-redirects": "1.16.0",
-      "fast-uri": "3.1.2",
+      "fast-uri": "3.1.4",
       "@babel/plugin-transform-modules-systemjs": "7.29.4",
       "uuid": "11.1.1",
       "js-yaml": "4.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,7 +36,7 @@ overrides:
   serialize-javascript: 7.0.5
   picomatch: 2.3.2
   follow-redirects: 1.16.0
-  fast-uri: 3.1.2
+  fast-uri: 3.1.4
   '@babel/plugin-transform-modules-systemjs': 7.29.4
   uuid: 11.1.1
   js-yaml: 4.3.0
@@ -2333,8 +2333,8 @@ packages:
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
-  fast-uri@3.1.2:
-    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
+  fast-uri@3.1.4:
+    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
 
   fastest-levenshtein@1.0.16:
     resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
@@ -6105,7 +6105,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.2
+      fast-uri: 3.1.4
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -6923,7 +6923,7 @@ snapshots:
 
   fast-json-stable-stringify@2.1.0: {}
 
-  fast-uri@3.1.2: {}
+  fast-uri@3.1.4: {}
 
   fastest-levenshtein@1.0.16: {}
 


### PR DESCRIPTION
## Summary

Resolves two high-severity `pnpm audit` findings against `fast-uri@3.1.2`
([GHSA-v2hh-gcrm-f6hx](https://github.com/advisories/GHSA-v2hh-gcrm-f6hx),
[GHSA-4c8g-83qw-93j6](https://github.com/advisories/GHSA-4c8g-83qw-93j6)) —
host-confusion parser bugs, patched in 3.1.4. The old pin `3.1.2` in
`pnpm.overrides` blocked the auto-upgrade.

No runtime impact: `fast-uri` exists only in the dev toolchain
(`webpack → schema-utils → ajv`), is absent from the production tree and the
build output. Audit/CI hygiene only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)