### PR TITLE
fix(deps): bump fast-uri override to 3.1.6 to resolve 4 high advisories

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
       "serialize-javascript": "7.0.5",
       "picomatch": "2.3.2",
       "follow-redirects": "1.16.0",
-      "fast-uri": "3.1.5",
+      "fast-uri": "3.1.6",
       "@babel/plugin-transform-modules-systemjs": "7.29.4",
       "uuid": "11.1.1",
       "js-yaml": "4.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,7 +37,7 @@ overrides:
   serialize-javascript: 7.0.5
   picomatch: 2.3.2
   follow-redirects: 1.16.0
-  fast-uri: 3.1.5
+  fast-uri: 3.1.6
   '@babel/plugin-transform-modules-systemjs': 7.29.4
   uuid: 11.1.1
   js-yaml: 4.3.1
@@ -2326,8 +2326,8 @@ packages:
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.6:
+    resolution: {integrity: sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==}
 
   fastest-levenshtein@1.0.16:
     resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
@@ -6096,7 +6096,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.6
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -6905,7 +6905,7 @@ snapshots:
 
   fast-json-stable-stringify@2.1.0: {}
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.6: {}
 
   fastest-levenshtein@1.0.16: {}
 


### PR DESCRIPTION
fast-uri@3.1.5 (via terser-webpack-plugin > schema-utils > ajv) is flagged high by pnpm audit, all fixed in 3.1.6:
- GHSA-5jgf-p345-68v8 / CVE-2026-75931: host confusion, skipped IDN canonicalization
- GHSA-f65p-4m7j-42xc / CVE-2026-75975: SSRF via malformed IPv6 normalization
- GHSA-fph4-wmhf-6fwf / CVE-2026-75899: SSRF via repeated hostname percent-decoding
- GHSA-jqff-g426-hqxp / CVE-2026-76172: host confusion, percent-encoded scheme

Build-time only (ajv schema validation for webpack plugin options); not in dist bundle. ajv range ^3.0.1 accepts 3.1.6. dist byte-identical; jest 239/239.