### PR TITLE
fix(deps): bump js-yaml override to 4.3.2 to resolve GHSA-2883-xcg3-v3hh

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
       "fast-uri": "3.1.6",
       "@babel/plugin-transform-modules-systemjs": "7.29.4",
       "uuid": "11.1.1",
-      "js-yaml": "4.3.1",
+      "js-yaml": "4.3.2",
       "launch-editor": "2.14.1",
       "websocket-driver": "0.7.5",
       "browserslist": "4.28.8"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,7 +40,7 @@ overrides:
   fast-uri: 3.1.6
   '@babel/plugin-transform-modules-systemjs': 7.29.4
   uuid: 11.1.1
-  js-yaml: 4.3.1
+  js-yaml: 4.3.2
   launch-editor: 2.14.1
   websocket-driver: 0.7.5
   browserslist: 4.28.8
@@ -2887,8 +2887,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.1:
-    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
+  js-yaml@4.3.2:
+    resolution: {integrity: sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==}
     hasBin: true
 
   jsesc@3.1.0:
@@ -5132,7 +5132,7 @@ snapshots:
       camelcase: 5.3.1
       find-up: 4.1.0
       get-package-type: 0.1.0
-      js-yaml: 4.3.1
+      js-yaml: 4.3.2
       resolve-from: 5.0.0
 
   '@istanbuljs/schema@0.1.3': {}
@@ -7662,7 +7662,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.1:
+  js-yaml@4.3.2:
     dependencies:
       argparse: 2.0.1
 


### PR DESCRIPTION
js-yaml 4.3.1 falls in the vulnerable range (>=4.0.0 <4.3.2) of the high severity advisory where maxTotalMergeKeys does not limit CPU use for empty merge sources. 4.3.2 is the minimal patched release on the 4.x line and carries an identical dependency set (argparse ^2.0.1), so this is a pure patch-level bump.

Only consumer is @istanbuljs/load-nyc-config via babel-plugin-istanbul in the jest coverage path; no source file imports js-yaml directly and it does not reach the production bundle.

Verified: pnpm test (54 suites / 239 tests) and pnpm run build both pass. pnpm audit high count 1 -> 0.